### PR TITLE
Add removing adjustable trait on removing last adjustable option. 

### DIFF
--- a/Document/Sources/Document/A11yDescription.swift
+++ b/Document/Sources/Document/A11yDescription.swift
@@ -43,7 +43,7 @@ public class A11yDescription: Codable {
     public var frame: CGRect
     
     // MARK: - Adjustable
-    public var adjustableOptions: AdjustableOptions // Not optional because user can input values, disable adjustable, but reenable after time. The app will keep data :-)
+    public private(set) var adjustableOptions: AdjustableOptions // Not optional because user can input values, disable adjustable, but reenable after time. The app will keep data :-)
     
     public var isAdjustable: Bool {
         get {
@@ -145,5 +145,25 @@ public class A11yDescription: Codable {
         }
         
         return descr.joined()
+    }
+    
+    public func addAdjustable(defaultValue: String = "") {
+        trait.formUnion(.adjustable)
+        adjustableOptions.add(defaultValue: defaultValue)
+    }
+    
+    public func updateAdustable(at index: Int, text: String) {
+        adjustableOptions.update(at: index, text: text)
+    }
+    
+    public func removeAdjustable(at index: Int) {
+        adjustableOptions.remove(at: index)
+        if adjustableOptions.isEmpty {
+            trait.remove(.adjustable)
+        }
+    }
+    
+    public func selectAdjustable(index: Int) {
+        adjustableOptions.currentIndex = index
     }
 }

--- a/Document/Sources/Document/A11yDescription.swift
+++ b/Document/Sources/Document/A11yDescription.swift
@@ -147,23 +147,24 @@ public class A11yDescription: Codable {
         return descr.joined()
     }
     
-    public func addAdjustable(defaultValue: String = "") {
+    public func addAdjustableOption(defaultValue: String = "") {
         trait.formUnion(.adjustable)
         adjustableOptions.add(defaultValue: defaultValue)
     }
     
-    public func updateAdustable(at index: Int, text: String) {
+    public func updateAdjustableOption(at index: Int, with text: String) {
         adjustableOptions.update(at: index, text: text)
     }
     
-    public func removeAdjustable(at index: Int) {
+    public func removeAdjustableOption(at index: Int) {
         adjustableOptions.remove(at: index)
         if adjustableOptions.isEmpty {
             trait.remove(.adjustable)
         }
     }
     
-    public func selectAdjustable(index: Int) {
+    public func selectAdjustableOption(at index: Int) {
         adjustableOptions.currentIndex = index
+        value = adjustableOptions.options[index]
     }
 }

--- a/Document/Sources/Document/AdjustableOptions.swift
+++ b/Document/Sources/Document/AdjustableOptions.swift
@@ -44,4 +44,8 @@ public struct AdjustableOptions: Codable {
             self.currentIndex = 0
         }
     }
+    
+    public var isEmpty: Bool {
+        options.isEmpty
+    }
 }

--- a/Document/Tests/DocumentTests/A11yDescriptionTests.swift
+++ b/Document/Tests/DocumentTests/A11yDescriptionTests.swift
@@ -50,6 +50,51 @@ class A11yDescriptionTests: XCTestCase {
         
         XCTAssertEqual(descr.voiceOverText, "Город: Екатеринбург. Недоступно. Кнопка")
     }
+    
+    
+    func test_whenRemoveLastAdjustableOption_shouldRemoveAdjustableTrait() {
+        let descr = A11yDescription.testMake(
+            value: "",
+            trait: .adjustable,
+            adjustableOption: .testMake(options: ["Маленькая", "Средняя", "Большая"],
+                                        currentIndex: 0)
+        )
+        
+        for option in descr.adjustableOptions.options {
+            if let index = descr.adjustableOptions.options.firstIndex(of: option) {
+                descr.removeAdjustableOption(at: index)
+            }
+        }
+        XCTAssertFalse(descr.trait.contains(.adjustable))
+        XCTAssertEqual(descr.adjustableOptions.isEmpty, true)
+    }
+    
+    func test_addingAdjustableOption_withSample() {
+        let descr = A11yDescription.testMake()
+        
+        let options = ["Маленькая", "Средняя", "Большая"]
+        
+        for option in options {
+            descr.addAdjustableOption(defaultValue: option)
+        }
+        XCTAssertTrue(descr.trait.contains(.adjustable))
+        XCTAssertEqual(descr.adjustableOptions.isEmpty, false)
+        XCTAssertEqual(descr.adjustableOptions.options.count, 3)
+    }
+    
+    func test_selectingAdjustableOption_shouldSetValue() {
+        let descr = A11yDescription.testMake(
+            label: "Пицца",
+            value: "Маленькая",
+            trait: .adjustable,
+            adjustableOption: .testMake(options: ["Маленькая", "Средняя"],
+                                        currentIndex: 0)
+        )
+        
+        descr.addAdjustableOption(defaultValue: "Большая")
+        descr.selectAdjustableOption(at: 2)
+        XCTAssertEqual(descr.voiceOverText, "Пицца: Большая. Элемент регулировки")
+    }
 }
 
 extension A11yDescription {

--- a/Settings/Settings/Value/A11yValueViewController.swift
+++ b/Settings/Settings/Value/A11yValueViewController.swift
@@ -65,9 +65,7 @@ class A11yValueViewController: NSViewController {
         
         if isAdjustable {
             let currentValue = view().valueTextField.stringValue
-            if !currentValue.isEmpty {
-                descr.adjustableOptions.add(defaultValue: currentValue)
-            }
+            descr.adjustableOptions.add(defaultValue: currentValue)
         }
         
         renderDescription()

--- a/Settings/Settings/Value/A11yValueViewController.swift
+++ b/Settings/Settings/Value/A11yValueViewController.swift
@@ -45,11 +45,7 @@ class A11yValueViewController: NSViewController {
     
     @IBAction func addAdjustable(_ sender: Any) {
         saveCurrentChanges()
-        
-        descr.trait.formUnion(.adjustable)
-        
-        descr.adjustableOptions.add()
-        
+        descr.addAdjustableOption()
         renderDescription()
     }
     
@@ -65,7 +61,7 @@ class A11yValueViewController: NSViewController {
         
         if isAdjustable {
             let currentValue = view().valueTextField.stringValue
-            descr.adjustableOptions.add(defaultValue: currentValue)
+            descr.addAdjustableOption(defaultValue: currentValue)
         }
         
         renderDescription()
@@ -84,22 +80,15 @@ class A11yValueViewController: NSViewController {
 extension A11yValueViewController: AdjustableOptionViewDelegate {
     func delete(option: AdjustableOptionView) {
         if let index = view().index(of: option) {
-            descr.adjustableOptions.remove(at: index)
-            if descr.adjustableOptions.isEmpty {
-                descr.trait.remove(.adjustable)
-            }
+            descr.removeAdjustableOption(at: index)
         }
-        
         renderDescription()
     }
     
     func select(option: AdjustableOptionView) {
         if let index = view().index(of: option) {
-            descr.adjustableOptions.currentIndex = index
+            descr.selectAdjustableOption(at: index)
         }
-        
-        descr.value = option.value // TODO: Should be on data's level
-        
         // TODO: Move to render
         view().optionsStack.arrangedSubviews
             .compactMap { view in
@@ -115,8 +104,8 @@ extension A11yValueViewController: AdjustableOptionViewDelegate {
     
     func update(option: AdjustableOptionView) {
         if let index = view().index(of: option) {
-            descr.adjustableOptions.update(at: index,
-                                           text: option.text)
+            descr.updateAdjustableOption(at: index,
+                                           with: option.text)
         }
     }
 }

--- a/Settings/Settings/Value/A11yValueViewController.swift
+++ b/Settings/Settings/Value/A11yValueViewController.swift
@@ -87,6 +87,9 @@ extension A11yValueViewController: AdjustableOptionViewDelegate {
     func delete(option: AdjustableOptionView) {
         if let index = view().index(of: option) {
             descr.adjustableOptions.remove(at: index)
+            if descr.adjustableOptions.isEmpty {
+                descr.trait.remove(.adjustable)
+            }
         }
         
         renderDescription()


### PR DESCRIPTION
# Description
This pr contains changes about behavior of adjustable trait

## Changes

- Added isEmpty property to AdjustableOptions.swift
- Added removing adjustable trait on removing last adjustable option
- Changed adding adjustable option with default value from valueTextField

**A11yControl:**

- Added addAdjustableOption(defaultValue: String = "") function
- Added removeAdjustableOption(at index: Int) function
- Added updateAdjustableOption(at index: Int, with text: String) function
- Added selectAdjustableOption(at index: Int) function

Also selectAdjustableOption now [sets](https://github.com/VODGroup/VoiceOverDesigner/pull/27/files#diff-b8ce61cb1440d1f1c2d44e8098d4dd510a3ed8d22bee4cb045efe68b17ed761fL100) the value of A11yControl

# Related Issue
* #22 

# Screenshots

https://user-images.githubusercontent.com/36012972/176900483-13730906-ab9f-470e-b069-5256f9781122.mp4


