### PR TITLE
Project Selection Screen

### DIFF
--- a/Document/Sources/Document/VODesignDocument+AppKit.swift
+++ b/Document/Sources/Document/VODesignDocument+AppKit.swift
@@ -85,5 +85,9 @@ public class VODesignDocument: Document {
         
         image = try? ImageSaveService().load(from: url)
     }
+    
+    public static func image(from url: URL) -> NSImage? {
+        try? ImageSaveService().load(from: url)
+    }
 }
 #endif

--- a/Projects/Projects.xcodeproj/project.pbxproj
+++ b/Projects/Projects.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		1E579B2628244A6B00B13565 /* ProjectsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E579B2528244A6B00B13565 /* ProjectsView.swift */; };
 		1E579BC628255FAC00B13565 /* CommonUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E579BC528255FAC00B13565 /* CommonUI.framework */; };
 		1E579BC728255FAC00B13565 /* CommonUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1E579BC528255FAC00B13565 /* CommonUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6B673FAD288357AA0067B171 /* ProjectsToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B673FAC288357AA0067B171 /* ProjectsToolbar.swift */; };
+		6B77F58D28820FE80035C064 /* ProjectCollectionViewItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B77F58C28820FE80035C064 /* ProjectCollectionViewItem.swift */; };
+		6B77F58F2882105D0035C064 /* ProjectCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B77F58E2882105D0035C064 /* ProjectCellView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +56,9 @@
 		1E579B19282446FE00B13565 /* Projects.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Projects.storyboard; sourceTree = "<group>"; };
 		1E579B2528244A6B00B13565 /* ProjectsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsView.swift; sourceTree = "<group>"; };
 		1E579BC528255FAC00B13565 /* CommonUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CommonUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B673FAC288357AA0067B171 /* ProjectsToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectsToolbar.swift; sourceTree = "<group>"; };
+		6B77F58C28820FE80035C064 /* ProjectCollectionViewItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCollectionViewItem.swift; sourceTree = "<group>"; };
+		6B77F58E2882105D0035C064 /* ProjectCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectCellView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,11 +104,13 @@
 		1E579AF6282446D200B13565 /* Projects */ = {
 			isa = PBXGroup;
 			children = (
+				6B673FAE28835C0B0067B171 /* Collection */,
 				1E579AF7282446D200B13565 /* Projects.h */,
 				1E579B17282446E900B13565 /* ProjectsViewController.swift */,
 				1E579B2528244A6B00B13565 /* ProjectsView.swift */,
 				1E579B19282446FE00B13565 /* Projects.storyboard */,
 				1E579AF8282446D200B13565 /* Projects.docc */,
+				6B673FAC288357AA0067B171 /* ProjectsToolbar.swift */,
 			);
 			path = Projects;
 			sourceTree = "<group>";
@@ -121,6 +129,15 @@
 				1E579BC528255FAC00B13565 /* CommonUI.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		6B673FAE28835C0B0067B171 /* Collection */ = {
+			isa = PBXGroup;
+			children = (
+				6B77F58C28820FE80035C064 /* ProjectCollectionViewItem.swift */,
+				6B77F58E2882105D0035C064 /* ProjectCellView.swift */,
+			);
+			path = Collection;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -239,7 +256,10 @@
 			files = (
 				1E579B2628244A6B00B13565 /* ProjectsView.swift in Sources */,
 				1E579AF9282446D200B13565 /* Projects.docc in Sources */,
+				6B77F58F2882105D0035C064 /* ProjectCellView.swift in Sources */,
 				1E579B18282446E900B13565 /* ProjectsViewController.swift in Sources */,
+				6B77F58D28820FE80035C064 /* ProjectCollectionViewItem.swift in Sources */,
+				6B673FAD288357AA0067B171 /* ProjectsToolbar.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Projects/Projects/Collection/ProjectCellView.swift
+++ b/Projects/Projects/Collection/ProjectCellView.swift
@@ -22,6 +22,7 @@ class ProjectCellView: NSView {
       let view = NSTextField()
         view.isEditable = false
         view.isBordered = false
+        view.alignment = .center
         return view
     }()
     

--- a/Projects/Projects/Collection/ProjectCellView.swift
+++ b/Projects/Projects/Collection/ProjectCellView.swift
@@ -1,0 +1,69 @@
+//
+//  ProjectCellView.swift
+//  Projects
+//
+//  Created by Andrey Plotnikov on 16.07.2022.
+//
+
+import Foundation
+
+import AppKit
+
+
+class ProjectCellView: NSView {
+    
+    lazy var thumbnail: NSImageView = {
+        let view = NSImageView(image: NSImage())
+        view.isEditable = false
+        return view
+    }()
+    
+    lazy var fileNameTextField: NSTextField = {
+      let view = NSTextField()
+        view.isEditable = false
+        view.isBordered = false
+        return view
+    }()
+    
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+    
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setup() {
+        addSubviews()
+        addConstraints()
+    }
+    
+    func addSubviews() {
+        [thumbnail, fileNameTextField].forEach(addSubview(_:))
+    }
+    
+    func addConstraints() {
+        thumbnail.translatesAutoresizingMaskIntoConstraints = false
+        fileNameTextField.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            thumbnail.topAnchor.constraint(equalTo: topAnchor),
+            thumbnail.bottomAnchor.constraint(equalTo: bottomAnchor),
+            thumbnail.leadingAnchor.constraint(equalTo: leadingAnchor),
+            thumbnail.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            fileNameTextField.bottomAnchor.constraint(equalTo: thumbnail.bottomAnchor),
+            fileNameTextField.widthAnchor.constraint(equalTo: widthAnchor),
+        ])
+
+    }
+}

--- a/Projects/Projects/Collection/ProjectCollectionViewItem.swift
+++ b/Projects/Projects/Collection/ProjectCollectionViewItem.swift
@@ -1,0 +1,27 @@
+//
+//  ProjectCell.swift
+//  Projects
+//
+//  Created by Andrey Plotnikov on 16.07.2022.
+//
+
+import Foundation
+import AppKit
+import Document
+
+class ProjectCollectionViewItem: NSCollectionViewItem {
+    static let identifier = NSUserInterfaceItemIdentifier(rawValue: String(describing: ProjectCollectionViewItem.self))
+    
+    let projectCellView = ProjectCellView()
+    
+    override func loadView() {
+        view = projectCellView
+    }
+    
+    func configure(image: NSImage?, fileName: String) {
+        projectCellView.thumbnail.image = image
+        projectCellView.fileNameTextField.stringValue = fileName
+        projectCellView.layoutSubtreeIfNeeded()
+    }
+        
+}

--- a/Projects/Projects/Projects.storyboard
+++ b/Projects/Projects/Projects.storyboard
@@ -2,73 +2,15 @@
 <document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="KyR-Ji-qI4">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
-        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Projects View Controller-->
         <scene sceneID="m6j-7H-VRt">
             <objects>
-                <viewController id="KyR-Ji-qI4" customClass="ProjectsViewController" customModule="Projects" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" id="riM-Xx-dn2" customClass="ProjectsView" customModule="Projects" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                        <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qyy-Gj-Eqz">
-                                <rect key="frame" x="168" y="134" width="114" height="31"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Drag here" id="3Sz-Hc-JpK">
-                                    <font key="font" textStyle="largeTitle" name=".SFNS-Regular"/>
-                                    <color key="textColor" name="tertiaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="I3D-TU-WYr">
-                                <rect key="frame" x="13" y="253" width="68" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="push" title="Menu" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="dI0-na-bRZ">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="selectMenu" target="KyR-Ji-qI4" id="kuW-zM-ZTu"/>
-                                </connections>
-                            </button>
-                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ab3-qf-JkQ">
-                                <rect key="frame" x="79" y="253" width="82" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="push" title="Product" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="V28-4Z-ASf">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="selectProductCard" target="KyR-Ji-qI4" id="aZu-oc-Ztm"/>
-                                </connections>
-                            </button>
-                            <imageView hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="PY1-w3-hFn">
-                                <rect key="frame" x="103" y="50" width="244" height="200"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="200" id="NL9-qr-R62"/>
-                                </constraints>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="A11y-man" id="Ktk-Yw-lPr"/>
-                            </imageView>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="qyy-Gj-Eqz" firstAttribute="centerY" secondItem="riM-Xx-dn2" secondAttribute="centerY" id="HwI-Yc-ODv"/>
-                            <constraint firstItem="qyy-Gj-Eqz" firstAttribute="centerX" secondItem="riM-Xx-dn2" secondAttribute="centerX" id="SlS-cl-X5f"/>
-                            <constraint firstItem="PY1-w3-hFn" firstAttribute="centerX" secondItem="riM-Xx-dn2" secondAttribute="centerX" id="pqP-by-q7p"/>
-                            <constraint firstItem="PY1-w3-hFn" firstAttribute="centerY" secondItem="riM-Xx-dn2" secondAttribute="centerY" id="yaL-tN-h99"/>
-                        </constraints>
-                        <connections>
-                            <outlet property="dragHereLabel" destination="qyy-Gj-Eqz" id="hyf-By-KBP"/>
-                            <outlet property="dragHereView" destination="PY1-w3-hFn" id="53J-fM-6GJ"/>
-                        </connections>
-                    </view>
-                </viewController>
+                <viewController id="KyR-Ji-qI4" customClass="ProjectsViewController" customModule="Projects" customModuleProvider="target" sceneMemberID="viewController"/>
                 <customObject id="Kn0-bV-vA7" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-20" y="54"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="A11y-man" width="244" height="306"/>
-    </resources>
 </document>

--- a/Projects/Projects/ProjectsToolbar.swift
+++ b/Projects/Projects/ProjectsToolbar.swift
@@ -1,0 +1,55 @@
+//
+//  ProjectsToolbar.swift
+//  Projects
+//
+//  Created by Andrey Plotnikov on 16.07.2022.
+//
+
+import Foundation
+import AppKit
+
+public class ProjectsToolbar: NSToolbar {
+    public override init(identifier: NSToolbar.Identifier) {
+        super.init(identifier: identifier)
+        delegate = self
+    }
+    
+    public lazy var addButton: NSButton = {
+        let button = NSButton(frame: .zero)
+        button.image = NSImage(systemSymbolName: "plus", accessibilityDescription: "Create New Project")
+        button.isBordered = false
+        return button
+    }()
+    
+}
+
+
+
+extension NSToolbarItem.Identifier {
+    static let createNewProject = NSToolbarItem.Identifier(rawValue: "CreateNewProject")
+}
+
+extension ProjectsToolbar: NSToolbarDelegate {
+    public func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        switch itemIdentifier {
+        case .createNewProject:
+            let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+            item.view = addButton
+            return item
+        default:
+            return nil
+        }
+    }
+
+    public func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.createNewProject]
+    }
+
+    public func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.createNewProject]
+    }
+}

--- a/Projects/Projects/ProjectsView.swift
+++ b/Projects/Projects/ProjectsView.swift
@@ -53,8 +53,8 @@ class ProjectsView: NSView {
         scrollViewCollectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             scrollViewCollectionView.topAnchor.constraint(equalTo: scrollViewCollectionView.superview!.topAnchor, constant: -10),
-            scrollViewCollectionView.leadingAnchor.constraint(equalTo: scrollViewCollectionView.superview!.leadingAnchor, constant: 10),
-            scrollViewCollectionView.trailingAnchor.constraint(equalTo: scrollViewCollectionView.superview!.trailingAnchor, constant: -10),
+            scrollViewCollectionView.leadingAnchor.constraint(equalTo: scrollViewCollectionView.superview!.leadingAnchor),
+            scrollViewCollectionView.trailingAnchor.constraint(equalTo: scrollViewCollectionView.superview!.trailingAnchor),
             scrollViewCollectionView.bottomAnchor.constraint(equalTo: scrollViewCollectionView.superview!.bottomAnchor, constant: 10)
         ])
     }

--- a/Projects/Projects/ProjectsView.swift
+++ b/Projects/Projects/ProjectsView.swift
@@ -16,6 +16,7 @@ class ProjectsView: NSView {
         let flowLayout = NSCollectionViewFlowLayout()
         flowLayout.scrollDirection = .vertical
         flowLayout.itemSize = CGSize(width: 100, height: 250)
+        flowLayout.sectionInset = .init(top: 16, left: 16, bottom: 0, right: 16)
         let collection = NSCollectionView()
         collection.collectionViewLayout = flowLayout
         collection.isSelectable = true
@@ -52,10 +53,10 @@ class ProjectsView: NSView {
     func addConstraints() {
         scrollViewCollectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            scrollViewCollectionView.topAnchor.constraint(equalTo: scrollViewCollectionView.superview!.topAnchor, constant: -10),
+            scrollViewCollectionView.topAnchor.constraint(equalTo: scrollViewCollectionView.superview!.topAnchor),
             scrollViewCollectionView.leadingAnchor.constraint(equalTo: scrollViewCollectionView.superview!.leadingAnchor),
             scrollViewCollectionView.trailingAnchor.constraint(equalTo: scrollViewCollectionView.superview!.trailingAnchor),
-            scrollViewCollectionView.bottomAnchor.constraint(equalTo: scrollViewCollectionView.superview!.bottomAnchor, constant: 10)
+            scrollViewCollectionView.bottomAnchor.constraint(equalTo: scrollViewCollectionView.superview!.bottomAnchor)
         ])
     }
 }

--- a/Projects/Projects/ProjectsView.swift
+++ b/Projects/Projects/ProjectsView.swift
@@ -8,15 +8,54 @@
 import AppKit
 import CommonUI
 
-class ProjectsView: DragNDropImageView {
+class ProjectsView: NSView {
     
-    @IBOutlet weak var dragHereView: NSImageView!
-    @IBOutlet weak var dragHereLabel: NSTextField!
+    var scrollViewCollectionView = NSScrollView()
     
-    override var isWaitingForFile: Bool {
-        didSet {
-            dragHereView.isHidden = !isWaitingForFile
-            dragHereLabel.isHidden = isWaitingForFile
-        }
+    lazy var collectionView: NSCollectionView = {
+        let flowLayout = NSCollectionViewFlowLayout()
+        flowLayout.scrollDirection = .vertical
+        flowLayout.itemSize = CGSize(width: 100, height: 250)
+        let collection = NSCollectionView()
+        collection.collectionViewLayout = flowLayout
+        collection.isSelectable = true
+        collection.register(ProjectCollectionViewItem.self, forItemWithIdentifier: ProjectCollectionViewItem.identifier)
+        return collection
+    }()
+    
+    
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+    
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setup()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setup() {
+        addSubviews()
+        addConstraints()
+    }
+    
+    func addSubviews() {
+        scrollViewCollectionView.documentView = collectionView
+        [scrollViewCollectionView].forEach(addSubview(_:))
+    }
+    
+    func addConstraints() {
+        scrollViewCollectionView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            scrollViewCollectionView.topAnchor.constraint(equalTo: scrollViewCollectionView.superview!.topAnchor, constant: -10),
+            scrollViewCollectionView.leadingAnchor.constraint(equalTo: scrollViewCollectionView.superview!.leadingAnchor, constant: 10),
+            scrollViewCollectionView.trailingAnchor.constraint(equalTo: scrollViewCollectionView.superview!.trailingAnchor, constant: -10),
+            scrollViewCollectionView.bottomAnchor.constraint(equalTo: scrollViewCollectionView.superview!.bottomAnchor, constant: 10)
+        ])
     }
 }

--- a/Projects/Projects/ProjectsViewController.swift
+++ b/Projects/Projects/ProjectsViewController.swift
@@ -8,7 +8,6 @@
 import AppKit
 import Document
 import CommonUI
-import Combine
 
 public protocol ProjectsRouter: AnyObject {
     func show(document: VODesignDocument) -> Void
@@ -21,9 +20,6 @@ public class ProjectsViewController: NSViewController {
     public weak var router: ProjectsRouter?
     
     public var toolbar = ProjectsToolbar()
-    
-    
-    var cancellables: Set<AnyCancellable> = []
     
     public override func viewDidLoad() {
         super.viewDidLoad()
@@ -43,7 +39,6 @@ public class ProjectsViewController: NSViewController {
     @objc func createNewProject() {
         let document = VODesignDocument()
         router?.show(document: document)
-        
     }
 
     
@@ -78,7 +73,7 @@ extension ProjectsViewController : NSCollectionViewDataSource {
     public func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
         let item = ProjectCollectionViewItem()
         if let url = documentController?.recentDocumentURLs[indexPath.item] {
-        item.configure(image: VODesignDocument.image(from: url), fileName: url.deletingPathExtension().lastPathComponent)
+            item.configure(image: VODesignDocument.image(from: url), fileName: url.deletingPathExtension().lastPathComponent)
         }
         return item
     }

--- a/Projects/ProjectsTests/ProjectCollectionViewItemTests.swift
+++ b/Projects/ProjectsTests/ProjectCollectionViewItemTests.swift
@@ -1,0 +1,41 @@
+//
+//  ProjectsViewControllerTests.swift
+//  ProjectsTests
+//
+//  Created by Andrey Plotnikov on 19.07.2022.
+//
+
+import XCTest
+@testable import Projects
+
+class ProjectCollectionViewItemTests: XCTestCase {
+    
+    private func makeSUT() -> ProjectCollectionViewItem {
+        let cell = ProjectCollectionViewItem()
+        return cell
+    }
+
+    func testConfiguringCollectionViewCell_WithSampleImageAndText() throws {
+        let sut = makeSUT()
+        let testImageA11yDescription = "TestA11yDescription"
+        let testImage = NSImage(systemSymbolName: "plus", accessibilityDescription: testImageA11yDescription)
+        let fileName = "TestFileName"
+        
+        sut.configure(image: testImage, fileName: fileName)
+        
+        XCTAssertEqual(sut.projectCellView.fileNameTextField.stringValue, fileName)
+        XCTAssertEqual(sut.projectCellView.thumbnail.image, testImage)
+        XCTAssertEqual(sut.projectCellView.thumbnail.image?.accessibilityDescription, testImageA11yDescription)
+    }
+    
+    func testConfiguringCollectionViewCell_WithNilImageAndText() throws {
+        let sut = makeSUT()
+        let fileName = "TestFileName"
+        
+        sut.configure(image: nil, fileName: fileName)
+        
+        XCTAssertEqual(sut.projectCellView.fileNameTextField.stringValue, fileName)
+        XCTAssertNil(sut.projectCellView.thumbnail.image)
+    }
+
+}

--- a/VoiceOver Designer/VODocumentController.swift
+++ b/VoiceOver Designer/VODocumentController.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 import AppKit
 import Document
 import Editor
@@ -20,7 +21,6 @@ extension VODesignDocument {
     public override func makeWindowControllers() {
         let controller = EditorViewController.fromStoryboard()
         controller.presenter.document = self
-    
         let window = NSWindow(contentViewController: controller)
         window.setContentSize(NSSize(width: 800, height: 600))
         
@@ -31,5 +31,19 @@ extension VODesignDocument {
         
         window.setFrameAutosaveName("windowFrame")
         window.makeKeyAndOrderFront(self)
+    }
+    
+    final func updateRecent() {
+        guard let fileURL = fileURL else { return }
+        var recentProjectPaths: [String] = UserDefaults.standard.array(
+            forKey: "recentProjectsPaths"
+        ) as? [String] ?? []
+        if let containedIndex = recentProjectPaths.firstIndex(of: fileURL.path) {
+            let value = recentProjectPaths.remove(at: containedIndex)
+            recentProjectPaths.insert(value, at: 0)
+        } else {
+            recentProjectPaths.insert(fileURL.path, at: 0)
+        }
+        UserDefaults.standard.set(recentProjectPaths, forKey: "recentProjectsPaths")
     }
 }

--- a/VoiceOver Designer/VODocumentController.swift
+++ b/VoiceOver Designer/VODocumentController.swift
@@ -32,18 +32,4 @@ extension VODesignDocument {
         window.setFrameAutosaveName("windowFrame")
         window.makeKeyAndOrderFront(self)
     }
-    
-    final func updateRecent() {
-        guard let fileURL = fileURL else { return }
-        var recentProjectPaths: [String] = UserDefaults.standard.array(
-            forKey: "recentProjectsPaths"
-        ) as? [String] ?? []
-        if let containedIndex = recentProjectPaths.firstIndex(of: fileURL.path) {
-            let value = recentProjectPaths.remove(at: containedIndex)
-            recentProjectPaths.insert(value, at: 0)
-        } else {
-            recentProjectPaths.insert(fileURL.path, at: 0)
-        }
-        UserDefaults.standard.set(recentProjectPaths, forKey: "recentProjectsPaths")
-    }
 }

--- a/VoiceOver Designer/WindowContoller.swift
+++ b/VoiceOver Designer/WindowContoller.swift
@@ -22,6 +22,7 @@ class WindowContoller: NSWindowController {
         super.windowDidLoad()
         
         let projects = ProjectsViewController.fromStoryboard()
+        window?.toolbar = projects.toolbar
         contentViewController = projects
         projects.router = self
     }
@@ -31,6 +32,7 @@ extension WindowContoller: ProjectsRouter {
     func show(document: VODesignDocument) {
 //        self.document = document
         document.addWindowController(self)
+        document.updateRecent()
         
         let controller = EditorViewController.fromStoryboard()
         controller.presenter.document = document

--- a/VoiceOver Designer/WindowContoller.swift
+++ b/VoiceOver Designer/WindowContoller.swift
@@ -22,6 +22,7 @@ class WindowContoller: NSWindowController {
         super.windowDidLoad()
         
         let projects = ProjectsViewController.fromStoryboard()
+        projects.documentController = VODocumentController.shared
         window?.toolbar = projects.toolbar
         contentViewController = projects
         projects.router = self
@@ -32,7 +33,6 @@ extension WindowContoller: ProjectsRouter {
     func show(document: VODesignDocument) {
 //        self.document = document
         document.addWindowController(self)
-        document.updateRecent()
         
         let controller = EditorViewController.fromStoryboard()
         controller.presenter.document = document


### PR DESCRIPTION
# Description
This pr contains changes about project selection screen

## Changes

### Added
- Added static func image(url: URL) to VODesignDocument to retrieve image for preview
- Added ProjectCellView, ProjectCollectionViewItem, ProjectsToolBar
- Added NSDocumentController property to ProjectsViewController as datasource for Collection
- Added new project button to Toolbar


### Changed
- changed ProjectsView to contain NSCollectionView
- remove views from Projects.storyboard

# TODO

- [x] Adding to recentPaths when saving new project for the first time
- [x] tests for all changes

# Related Issue
* #15

# Screenshots

<img width="912" alt="Screenshot 2022-07-17 at 16 32 13" src="https://user-images.githubusercontent.com/36012972/179400845-bbc618b7-6107-4500-a6b5-297ed1e8a390.png">


https://user-images.githubusercontent.com/36012972/179401442-a7d7a1a5-c405-4e0f-bf8d-39b671bbc12b.mov


