### PR TITLE
Adjustable controls for Preview

### DIFF
--- a/Document/Sources/Document/A11yDescription.swift
+++ b/Document/Sources/Document/A11yDescription.swift
@@ -169,12 +169,12 @@ public class A11yDescription: Codable {
     }
     
     public func accessibilityIncrement() {
-        adjustableOptions.accesibilityIncrement()
+        adjustableOptions.accessibilityIncrement()
         value = adjustableOptions.currentValue ?? ""
     }
     
-    public func accesibilityDecrement() {
-        adjustableOptions.accesibilityDecrement()
+    public func accessibilityDecrement() {
+        adjustableOptions.accessibilityDecrement()
         value = adjustableOptions.currentValue ?? ""
     }
 }

--- a/Document/Sources/Document/A11yDescription.swift
+++ b/Document/Sources/Document/A11yDescription.swift
@@ -167,4 +167,14 @@ public class A11yDescription: Codable {
         adjustableOptions.currentIndex = index
         value = adjustableOptions.options[index]
     }
+    
+    public func accessibilityIncrement() {
+        adjustableOptions.accesibilityIncrement()
+        value = adjustableOptions.currentValue ?? ""
+    }
+    
+    public func accesibilityDecrement() {
+        adjustableOptions.accesibilityDecrement()
+        value = adjustableOptions.currentValue ?? ""
+    }
 }

--- a/Document/Sources/Document/AdjustableOptions.swift
+++ b/Document/Sources/Document/AdjustableOptions.swift
@@ -18,6 +18,12 @@ public struct AdjustableOptions: Codable {
     
     public private(set) var options: [String]
     public var currentIndex: Int?
+    public var currentValue: String? {
+        guard let currentIndex = currentIndex else {
+            return nil
+        }
+        return options[currentIndex]
+    }
     
     public mutating func remove(at index: Int) {
         options.remove(at: index)
@@ -47,5 +53,19 @@ public struct AdjustableOptions: Codable {
     
     public var isEmpty: Bool {
         options.isEmpty
+    }
+    
+    public mutating func accesibilityIncrement() {
+        guard let currentIndex = currentIndex, currentIndex < options.count - 1 else {
+            return
+        }
+        self.currentIndex = currentIndex + 1
+    }
+    
+    public mutating func accesibilityDecrement() {
+        guard let currentIndex = currentIndex, currentIndex > 0 else {
+            return
+        }
+        self.currentIndex = currentIndex - 1
     }
 }

--- a/Document/Sources/Document/AdjustableOptions.swift
+++ b/Document/Sources/Document/AdjustableOptions.swift
@@ -55,14 +55,14 @@ public struct AdjustableOptions: Codable {
         options.isEmpty
     }
     
-    public mutating func accesibilityIncrement() {
+    public mutating func accessibilityIncrement() {
         guard let currentIndex = currentIndex, currentIndex < options.count - 1 else {
             return
         }
         self.currentIndex = currentIndex + 1
     }
     
-    public mutating func accesibilityDecrement() {
+    public mutating func accessibilityDecrement() {
         guard let currentIndex = currentIndex, currentIndex > 0 else {
             return
         }

--- a/Document/Sources/Document/DocumentSaveService.swift
+++ b/Document/Sources/Document/DocumentSaveService.swift
@@ -28,40 +28,6 @@ class DocumentSaveService {
 }
 
 
-class ImageSaveService {
-    func load(from path: URL) throws -> Image? {
-        let imageURL = path.appendingPathComponent("screen.png")
-        let data = try Data(contentsOf: imageURL)
-        return Image(data: data)
-    }
-}
 
-#if os(iOS)
-import UIKit
-public typealias Image = UIImage
-
-#elseif os(macOS)
-import AppKit
-public typealias Image = NSImage
-extension ImageSaveService {
-    
-    func save(image: NSImage, to path: URL) throws {
-        if let data = UIImagePNGRepresentation(image) {
-            try data.write(to: path.appendingPathComponent("screen.png"))
-        } else {
-            // TODO: Handle errors
-        }
-    }
-    
-    func UIImagePNGRepresentation(_ image: Image) -> Data? {
-        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
-        else { return nil }
-        let imageRep = NSBitmapImageRep(cgImage: cgImage)
-        imageRep.size = image.size // display size in points
-        return imageRep.representation(using: .png, properties: [:])
-    }
-}
-
-#endif
 
 

--- a/Document/Sources/Document/DocumentSaveService.swift
+++ b/Document/Sources/Document/DocumentSaveService.swift
@@ -27,11 +27,23 @@ class DocumentSaveService {
     }
 }
 
+
+class ImageSaveService {
+    func load(from path: URL) throws -> Image? {
+        let imageURL = path.appendingPathComponent("screen.png")
+        let data = try Data(contentsOf: imageURL)
+        return Image(data: data)
+    }
+}
+
 #if os(iOS)
+import UIKit
+public typealias Image = UIImage
 
 #elseif os(macOS)
 import AppKit
-class ImageSaveService {
+public typealias Image = NSImage
+extension ImageSaveService {
     
     func save(image: NSImage, to path: URL) throws {
         if let data = UIImagePNGRepresentation(image) {
@@ -41,15 +53,7 @@ class ImageSaveService {
         }
     }
     
-    func load(from path: URL) throws -> NSImage? {
-        let imageURL = path.appendingPathComponent("screen.png")
-        guard let data = try? Data(contentsOf: imageURL) else {
-            return nil
-        }
-        return NSImage(data: data)
-    }
-    
-    func UIImagePNGRepresentation(_ image: NSImage) -> Data? {
+    func UIImagePNGRepresentation(_ image: Image) -> Data? {
         guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
         else { return nil }
         let imageRep = NSBitmapImageRep(cgImage: cgImage)

--- a/Document/Sources/Document/ImageSaveService.swift
+++ b/Document/Sources/Document/ImageSaveService.swift
@@ -1,0 +1,45 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Plotnikov on 22.07.2022.
+//
+
+import Foundation
+
+class ImageSaveService {
+    func load(from path: URL) throws -> Image? {
+        let imageURL = path.appendingPathComponent("screen.png")
+        let data = try Data(contentsOf: imageURL)
+        return Image(data: data)
+    }
+}
+
+#if os(iOS)
+import UIKit
+public typealias Image = UIImage
+
+#elseif os(macOS)
+import AppKit
+public typealias Image = NSImage
+extension ImageSaveService {
+    
+    func save(image: NSImage, to path: URL) throws {
+        if let data = UIImagePNGRepresentation(image) {
+            try data.write(to: path.appendingPathComponent("screen.png"))
+        } else {
+            // TODO: Handle errors
+        }
+    }
+    
+    func UIImagePNGRepresentation(_ image: Image) -> Data? {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil)
+        else { return nil }
+        let imageRep = NSBitmapImageRep(cgImage: cgImage)
+        imageRep.size = image.size // display size in points
+        return imageRep.representation(using: .png, properties: [:])
+    }
+}
+
+#endif
+

--- a/Document/Sources/Document/ImageSaveService.swift
+++ b/Document/Sources/Document/ImageSaveService.swift
@@ -24,7 +24,7 @@ import AppKit
 public typealias Image = NSImage
 extension ImageSaveService {
     
-    func save(image: NSImage, to path: URL) throws {
+    func save(image: Image, to path: URL) throws {
         if let data = UIImagePNGRepresentation(image) {
             try data.write(to: path.appendingPathComponent("screen.png"))
         } else {

--- a/Document/Sources/Document/VODesignDocument+AppKit.swift
+++ b/Document/Sources/Document/VODesignDocument+AppKit.swift
@@ -4,6 +4,7 @@ import AppKit
 public typealias Document = NSDocument
 
 import os
+import Foundation
 
 public class VODesignDocument: Document {
     public static var vodesign = "vodesign"
@@ -54,9 +55,14 @@ public class VODesignDocument: Document {
         let package = FileWrapper(directoryWithFileWrappers: [:])
         
         package.addFileWrapper(try controlsWrapper())
+
         
         if let imageWrapper = imageWrapper() {
             package.addFileWrapper(imageWrapper)
+        }
+        
+        if let previewWrapper = previewWrapper() {
+            package.addFileWrapper(previewWrapper)
         }
      
         return package
@@ -77,6 +83,17 @@ public class VODesignDocument: Document {
         imageWrapper.preferredFilename = "screen.png"
             
         return imageWrapper
+    }
+    
+    private func previewWrapper() -> FileWrapper? {
+        guard let image = image,
+            let imageData = ImageSaveService().UIImagePNGRepresentation(image)
+        else { return nil }
+        let imageWrapper = FileWrapper(regularFileWithContents: imageData)
+        imageWrapper.preferredFilename = "Preview.png"
+        let quicklookWrapper = FileWrapper(directoryWithFileWrappers: ["QuickLook": imageWrapper])
+        quicklookWrapper.preferredFilename = "QuickLook"
+        return quicklookWrapper
     }
     
     public override func read(from url: URL, ofType typeName: String) throws {

--- a/Document/Sources/Document/VODesignDocument+AppKit.swift
+++ b/Document/Sources/Document/VODesignDocument+AppKit.swift
@@ -2,13 +2,14 @@
 // MARK: - AppKit
 import AppKit
 public typealias Document = NSDocument
+
 import os
 
 public class VODesignDocument: Document {
     public static var vodesign = "vodesign"
     
     // MARK: - Data
-    public var image: NSImage?
+    public var image: Image?
     
     public var controls: [A11yDescription] = [] {
         didSet {
@@ -86,7 +87,7 @@ public class VODesignDocument: Document {
         image = try? ImageSaveService().load(from: url)
     }
     
-    public static func image(from url: URL) -> NSImage? {
+    public static func image(from url: URL) -> Image? {
         try? ImageSaveService().load(from: url)
     }
 }

--- a/Document/Sources/Document/VODesignDocument+UIKit.swift
+++ b/Document/Sources/Document/VODesignDocument+UIKit.swift
@@ -3,6 +3,7 @@ import UIKit
 public typealias Document = UIDocument
 
 
+
 public class VODesignDocument: Document {
     public convenience init(fileName: String,
                             rootPath: URL = iCloudContainer) {
@@ -20,6 +21,7 @@ public class VODesignDocument: Document {
     }
     
     public var controls: [A11yDescription] = []
+    public var image: Image?
     
     lazy var saveService: DocumentSaveService = DocumentSaveService(fileURL: fileURL
         .appendingPathComponent("controls.json"))
@@ -51,6 +53,7 @@ public class VODesignDocument: Document {
     
     public override func read(from url: URL) throws {
         controls = try DocumentSaveService(fileURL: url.appendingPathComponent("controls.json")).loadControls()
+        image = try? ImageSaveService().load(from: url)
     }
 }
 

--- a/Document/Tests/DocumentTests/AdjustableOptionsTests.swift
+++ b/Document/Tests/DocumentTests/AdjustableOptionsTests.swift
@@ -46,4 +46,32 @@ class AdjustableOptionsTests: XCTestCase {
         
         XCTAssertNil(sut.currentIndex)
     }
+    
+    func test_accessibillityIncrement_shouldChangeValueAndIndex() {
+        var sut = AdjustableOptions(options: ["First", "Second"], currentIndex: 0)
+        sut.accessibilityIncrement()
+        XCTAssertEqual(sut.currentIndex, 1)
+        XCTAssertEqual(sut.currentValue, "Second")
+    }
+    
+    func test_accessibillityIncrement_shouldnotChangeValueAndIndex() {
+        var sut = AdjustableOptions(options: ["First"], currentIndex: 0)
+        sut.accessibilityIncrement()
+        XCTAssertEqual(sut.currentIndex, 0)
+        XCTAssertEqual(sut.currentValue, "First")
+    }
+    
+    func test_accessibillityDecrement_shouldChangeValueAndIndex() {
+        var sut = AdjustableOptions(options: ["First", "Second"], currentIndex: 1)
+        sut.accessibilityDecrement()
+        XCTAssertEqual(sut.currentIndex, 0)
+        XCTAssertEqual(sut.currentValue, "First")
+    }
+    
+    func test_accessibillityDecrement_shouldnotChangeValueAndIndex() {
+        var sut = AdjustableOptions(options: ["First"], currentIndex: 0)
+        sut.accessibilityDecrement()
+        XCTAssertEqual(sut.currentIndex, 0)
+        XCTAssertEqual(sut.currentValue, "First")
+    }
 }

--- a/VoiceOver Preview/VoiceOver Preview.xcodeproj/project.pbxproj
+++ b/VoiceOver Preview/VoiceOver Preview.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		1EEB1BF0281E3DA200615EA9 /* VoiceOver_PreviewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEB1BEF281E3DA200615EA9 /* VoiceOver_PreviewUITests.swift */; };
 		1EEB1BF2281E3DA200615EA9 /* VoiceOver_PreviewUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEB1BF1281E3DA200615EA9 /* VoiceOver_PreviewUITestsLaunchTests.swift */; };
 		1EEB1BFF281E3EF600615EA9 /* VoiceOver_PreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEB1BFE281E3EF600615EA9 /* VoiceOver_PreviewTests.swift */; };
-		6BABB3552889BC5400FF259E /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BABB3542889BC5400FF259E /* CloudKit.framework */; };
 		6BF087492889DB6600055C78 /* VoiceOverElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF087482889DB6600055C78 /* VoiceOverElement.swift */; };
 		6BF0874B288AAB4B00055C78 /* PreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF0874A288AAB4B00055C78 /* PreviewView.swift */; };
 /* End PBXBuildFile section */
@@ -68,7 +67,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				1E0338FF281E732600EE373E /* Document in Frameworks */,
-				6BABB3552889BC5400FF259E /* CloudKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VoiceOver Preview/VoiceOver Preview.xcodeproj/project.pbxproj
+++ b/VoiceOver Preview/VoiceOver Preview.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		1EEB1BF0281E3DA200615EA9 /* VoiceOver_PreviewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEB1BEF281E3DA200615EA9 /* VoiceOver_PreviewUITests.swift */; };
 		1EEB1BF2281E3DA200615EA9 /* VoiceOver_PreviewUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEB1BF1281E3DA200615EA9 /* VoiceOver_PreviewUITestsLaunchTests.swift */; };
 		1EEB1BFF281E3EF600615EA9 /* VoiceOver_PreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EEB1BFE281E3EF600615EA9 /* VoiceOver_PreviewTests.swift */; };
+		6BABB3552889BC5400FF259E /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BABB3542889BC5400FF259E /* CloudKit.framework */; };
+		6BF087492889DB6600055C78 /* VoiceOverElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF087482889DB6600055C78 /* VoiceOverElement.swift */; };
+		6BF0874B288AAB4B00055C78 /* PreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF0874A288AAB4B00055C78 /* PreviewView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +57,9 @@
 		1EEB1BFE281E3EF600615EA9 /* VoiceOver_PreviewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VoiceOver_PreviewTests.swift; sourceTree = "<group>"; };
 		1EEB1C02281E706B00615EA9 /* controls.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = controls.json; sourceTree = "<group>"; };
 		1EEB1C08281E718700615EA9 /* Document.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Document.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6BABB3542889BC5400FF259E /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
+		6BF087482889DB6600055C78 /* VoiceOverElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceOverElement.swift; sourceTree = "<group>"; };
+		6BF0874A288AAB4B00055C78 /* PreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,6 +68,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1E0338FF281E732600EE373E /* Document in Frameworks */,
+				6BABB3552889BC5400FF259E /* CloudKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,6 +122,8 @@
 				1EEB1C02281E706B00615EA9 /* controls.json */,
 				1EEB1BD9281E3DA100615EA9 /* LaunchScreen.storyboard */,
 				1EEB1BDC281E3DA100615EA9 /* Info.plist */,
+				6BF087482889DB6600055C78 /* VoiceOverElement.swift */,
+				6BF0874A288AAB4B00055C78 /* PreviewView.swift */,
 			);
 			path = "VoiceOver Preview";
 			sourceTree = "<group>";
@@ -139,6 +148,7 @@
 		1EEB1C07281E718700615EA9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6BABB3542889BC5400FF259E /* CloudKit.framework */,
 				1EEB1C08281E718700615EA9 /* Document.framework */,
 			);
 			name = Frameworks;
@@ -280,7 +290,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6BF0874B288AAB4B00055C78 /* PreviewView.swift in Sources */,
 				1EEB1BD3281E3DA000615EA9 /* PreviewViewController.swift in Sources */,
+				6BF087492889DB6600055C78 /* VoiceOverElement.swift in Sources */,
 				1EEB1BCF281E3DA000615EA9 /* AppDelegate.swift in Sources */,
 				1EEB1BD1281E3DA000615EA9 /* SceneDelegate.swift in Sources */,
 			);

--- a/VoiceOver Preview/VoiceOver Preview/Base.lproj/Main.storyboard
+++ b/VoiceOver Preview/VoiceOver Preview/Base.lproj/Main.storyboard
@@ -16,19 +16,8 @@
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="PreviewView" customModule="VoiceOver_Preview" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="MenuSample" translatesAutoresizingMaskIntoConstraints="NO" id="SrJ-0r-IT6">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                            </imageView>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="SrJ-0r-IT6" firstAttribute="top" secondItem="8bC-Xf-vdC" secondAttribute="top" id="7Yu-LP-ruH"/>
-                            <constraint firstAttribute="bottom" secondItem="SrJ-0r-IT6" secondAttribute="bottom" id="p29-Us-ztn"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="SrJ-0r-IT6" secondAttribute="trailing" id="qCA-pZ-qap"/>
-                            <constraint firstItem="SrJ-0r-IT6" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="w3i-qE-yTl"/>
-                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -37,7 +26,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="MenuSample" width="1170" height="2532"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/VoiceOver Preview/VoiceOver Preview/PreviewView.swift
+++ b/VoiceOver Preview/VoiceOver Preview/PreviewView.swift
@@ -1,0 +1,53 @@
+//
+//  PreviewView.swift
+//  VoiceOver Preview
+//
+//  Created by Andrey Plotnikov on 22.07.2022.
+//
+
+import Foundation
+import UIKit
+
+class PreviewView: UIView {
+    
+    var layout: VoiceOverLayout? {
+        didSet {
+            accessibilityElements = layout?.accessibilityElements
+        }
+    }
+    
+    lazy var imageView: UIImageView = {
+       let imageView = UIImageView(image: nil)
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setup() {
+        addSubviews()
+        addConstraints()
+    }
+    
+    func addSubviews() {
+        [imageView].forEach(addSubview(_:))
+    }
+    
+    func addConstraints() {
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            imageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+}

--- a/VoiceOver Preview/VoiceOver Preview/PreviewViewController.swift
+++ b/VoiceOver Preview/VoiceOver Preview/PreviewViewController.swift
@@ -9,10 +9,18 @@ import UIKit
 import Document
 
 final class PreviewViewController: UIViewController {
+    
+    lazy var documentBrowser: UIDocumentBrowserViewController = {
+        let controller = UIDocumentBrowserViewController()
+        controller.allowsPickingMultipleItems = false
+        controller.allowsDocumentCreation = false
+      return controller
+    }()
+
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        documentBrowser.delegate = self
         loadAndDraw()
         
         NotificationCenter.default.addObserver(
@@ -51,9 +59,13 @@ final class PreviewViewController: UIViewController {
         document.close()
         
         document.open { isSuccess in
+            if isSuccess {
+                self.document.controls.forEach(self.drawingService.drawControl(from:))
+                self.view().layout = VoiceOverLayout(controls: self.document.controls, container: self.view)
+            } else {
+                self.present(self.documentBrowser, animated: true)
+            }
             
-            self.document.controls.forEach(self.drawingService.drawControl(from:))
-            self.view().layout = VoiceOverLayout(controls: self.document.controls, container: self.view)
         }
     }
 }
@@ -64,6 +76,31 @@ class PreviewView: UIView {
             accessibilityElements = layout?.accessibilityElements
         }
     }
+    
+    override func accessibilityIncrement() {
+        super.accessibilityIncrement()
+        layout?.focusedElement?.accessibilityIncrement()
+    }
+    
+    override func accessibilityDecrement() {
+        super.accessibilityDecrement()
+        layout?.focusedElement?.accessibilityDecrement()
+    }
+    
+    
+}
+
+extension PreviewViewController: UIDocumentBrowserViewControllerDelegate {
+    func documentBrowser(_ controller: UIDocumentBrowserViewController, didPickDocumentsAt documentURLs: [URL]) {
+        if let url = documentURLs.first {
+            let document = VODesignDocument(fileURL: url)
+            self.document = document
+            loadAndDraw()
+            documentBrowser.dismiss(animated: true)
+        }
+    }
+    
+    
 }
 
 class VoiceOverLayout {
@@ -76,17 +113,27 @@ class VoiceOverLayout {
     }
     
     private func accessibilityElement(from control: A11yDescription) -> UIAccessibilityElement {
-        let element = UIAccessibilityElement(accessibilityContainer: container)
+        let element = VoiceOverElement(accessibilityContainer: container)
+        element.control = control
         element.isAccessibilityElement = true
         element.accessibilityLabel = control.label
         element.accessibilityValue = control.value
         element.accessibilityHint = control.hint
         element.accessibilityFrame = control.frame
         element.accessibilityTraits = control.trait.accessibilityTrait
+        
         return element
     }
     
     var accessibilityElements: [UIAccessibilityElement] {
         controls.map(accessibilityElement(from:))
     }
+    
+    /// A11y element that currently focused by VoiceOver
+    var focusedElement: UIAccessibilityElement? {
+        accessibilityElements.first(where: {$0.accessibilityElementIsFocused()})
+    }
+    
 }
+
+

--- a/VoiceOver Preview/VoiceOver Preview/PreviewViewController.swift
+++ b/VoiceOver Preview/VoiceOver Preview/PreviewViewController.swift
@@ -50,6 +50,10 @@ final class PreviewViewController: UIViewController {
         #endif
     }()
     
+    override func loadView() {
+        view = PreviewView(frame: .zero)
+    }
+    
     func view() -> PreviewView {
         view as! PreviewView
     }
@@ -62,6 +66,7 @@ final class PreviewViewController: UIViewController {
             if isSuccess {
                 self.document.controls.forEach(self.drawingService.drawControl(from:))
                 self.view().layout = VoiceOverLayout(controls: self.document.controls, container: self.view)
+                self.view().imageView.image = self.document.image
             } else {
                 self.present(self.documentBrowser, animated: true)
             }
@@ -70,13 +75,7 @@ final class PreviewViewController: UIViewController {
     }
 }
 
-class PreviewView: UIView {
-    var layout: VoiceOverLayout? {
-        didSet {
-            accessibilityElements = layout?.accessibilityElements
-        }
-    }
-}
+
 
 extension PreviewViewController: UIDocumentBrowserViewControllerDelegate {
     func documentBrowser(_ controller: UIDocumentBrowserViewController, didPickDocumentsAt documentURLs: [URL]) {

--- a/VoiceOver Preview/VoiceOver Preview/PreviewViewController.swift
+++ b/VoiceOver Preview/VoiceOver Preview/PreviewViewController.swift
@@ -100,16 +100,7 @@ class VoiceOverLayout {
     }
     
     private func accessibilityElement(from control: A11yDescription) -> UIAccessibilityElement {
-        let element = VoiceOverElement(accessibilityContainer: container)
-        element.control = control
-        element.isAccessibilityElement = true
-        element.accessibilityLabel = control.label
-        element.accessibilityValue = control.value
-        element.accessibilityHint = control.hint
-        element.accessibilityFrame = control.frame
-        element.accessibilityTraits = control.trait.accessibilityTrait
-        
-        return element
+        VoiceOverElement(control: control, accessibilityContainer: container) 
     }
     
     var accessibilityElements: [UIAccessibilityElement] {

--- a/VoiceOver Preview/VoiceOver Preview/PreviewViewController.swift
+++ b/VoiceOver Preview/VoiceOver Preview/PreviewViewController.swift
@@ -76,18 +76,6 @@ class PreviewView: UIView {
             accessibilityElements = layout?.accessibilityElements
         }
     }
-    
-    override func accessibilityIncrement() {
-        super.accessibilityIncrement()
-        layout?.focusedElement?.accessibilityIncrement()
-    }
-    
-    override func accessibilityDecrement() {
-        super.accessibilityDecrement()
-        layout?.focusedElement?.accessibilityDecrement()
-    }
-    
-    
 }
 
 extension PreviewViewController: UIDocumentBrowserViewControllerDelegate {
@@ -127,11 +115,6 @@ class VoiceOverLayout {
     
     var accessibilityElements: [UIAccessibilityElement] {
         controls.map(accessibilityElement(from:))
-    }
-    
-    /// A11y element that currently focused by VoiceOver
-    var focusedElement: UIAccessibilityElement? {
-        accessibilityElements.first(where: {$0.accessibilityElementIsFocused()})
     }
     
 }

--- a/VoiceOver Preview/VoiceOver Preview/VoiceOverElement.swift
+++ b/VoiceOver Preview/VoiceOver Preview/VoiceOverElement.swift
@@ -12,26 +12,26 @@ import UIKit
 class VoiceOverElement: UIAccessibilityElement {
     var control: A11yDescription! {
         didSet {
-            accessibilityElement(from: control)
+            setup(from: control)
         }
     }
     
-    private func accessibilityElement(from control: A11yDescription) {
+    private func setup(from model: A11yDescription) {
         isAccessibilityElement = true
-        accessibilityLabel = control.label
-        accessibilityValue = control.value
-        accessibilityHint = control.hint
-        accessibilityFrame = control.frame
-        accessibilityTraits = control.trait.accessibilityTrait
+        accessibilityLabel = model.label
+        accessibilityValue = model.value
+        accessibilityHint = model.hint
+        accessibilityFrame = model.frame
+        accessibilityTraits = model.trait.accessibilityTrait
     }
     
     override func accessibilityIncrement() {
         control.accessibilityIncrement()
-        accessibilityElement(from: control)
+        setup(from: control)
     }
     
     override func accessibilityDecrement() {
-        control.accesibilityDecrement()
-        accessibilityElement(from: control)
+        control.accessibilityDecrement()
+        setup(from: control)
     }
 }

--- a/VoiceOver Preview/VoiceOver Preview/VoiceOverElement.swift
+++ b/VoiceOver Preview/VoiceOver Preview/VoiceOverElement.swift
@@ -1,0 +1,37 @@
+//
+//  VoiceOverElement.swift
+//  VoiceOver Preview
+//
+//  Created by Andrey Plotnikov on 21.07.2022.
+//
+
+import Foundation
+import Document
+import UIKit
+
+class VoiceOverElement: UIAccessibilityElement {
+    var control: A11yDescription! {
+        didSet {
+            accessibilityElement(from: control)
+        }
+    }
+    
+    private func accessibilityElement(from control: A11yDescription) {
+        isAccessibilityElement = true
+        accessibilityLabel = control.label
+        accessibilityValue = control.value
+        accessibilityHint = control.hint
+        accessibilityFrame = control.frame
+        accessibilityTraits = control.trait.accessibilityTrait
+    }
+    
+    override func accessibilityIncrement() {
+        control.accessibilityIncrement()
+        accessibilityElement(from: control)
+    }
+    
+    override func accessibilityDecrement() {
+        control.accesibilityDecrement()
+        accessibilityElement(from: control)
+    }
+}

--- a/VoiceOver Preview/VoiceOver Preview/VoiceOverElement.swift
+++ b/VoiceOver Preview/VoiceOver Preview/VoiceOverElement.swift
@@ -10,10 +10,16 @@ import Document
 import UIKit
 
 class VoiceOverElement: UIAccessibilityElement {
-    var control: A11yDescription! {
+    var control: A11yDescription {
         didSet {
             setup(from: control)
         }
+    }
+    
+    init(control: A11yDescription, accessibilityContainer: Any) {
+        self.control = control
+        super.init(accessibilityContainer: accessibilityContainer)
+        setup(from: control)
     }
     
     private func setup(from model: A11yDescription) {


### PR DESCRIPTION
# Description
This pr contains changes about adjustable controls for Preview App

## Changes

### Added:


#### VoiceOverElement
- subclassed VoiceOverElement: UIAccessibilityElement to override adjustableActions to trigger adjustableOptions

#### AdjustableOptions
- Added currentValue: String? 
- Added accessibilityDecrement()
- Added accessibilityIncrement()

#### A11yDescription
- Added accessibilityDecrement()
- Added accessibilityIncrement()

### VODocument
- Added Preview image filewrapper to display via QuickLook

### Changed
- changed PreviewViewController to show UIDocumentBrowserView if it's can't load document
- remove views from Main

# TODO

- [x] Add UIImageView to display document image
- [x] tests for all changes

# Related Issue
* #21

# Screenshots

https://user-images.githubusercontent.com/36012972/180419427-5843f885-2d35-4ec9-932b-c0af83666b70.mp4



