### PR TITLE
Add ability to undo delete action (#46)

### DIFF
--- a/VoiceOver Designer/Features/Sources/Editor/EditorPresenter.swift
+++ b/VoiceOver Designer/Features/Sources/Editor/EditorPresenter.swift
@@ -53,7 +53,7 @@ public class EditorPresenter {
         switch action {
         case let new as NewControlAction:
             document.undoManager?.registerUndo(withTarget: self, handler: { target in
-                target.delete(control: new.control)
+                target.delete(control: new.control, isUndoAvailable: false)
             })
             
             save()
@@ -107,7 +107,16 @@ extension EditorPresenter: SettingsDelegate {
         save()
     }
     
-    public func delete(control: A11yControl) {
+    public func delete(control: A11yControl, isUndoAvailable: Bool) {
+        if isUndoAvailable {
+            document.undoManager?.registerUndo(withTarget: self, handler: { target in
+                guard let a11yDescription = control.a11yDescription else {
+                    return
+                }
+                target.drawingController.drawControl(from: a11yDescription)
+            })
+        }
+        
         ui.delete(control: control)
         save()
     }

--- a/VoiceOver Designer/Features/Sources/Settings/SettingsPresenter.swift
+++ b/VoiceOver Designer/Features/Sources/Settings/SettingsPresenter.swift
@@ -10,7 +10,7 @@ import Document
 
 public protocol SettingsDelegate: AnyObject {
     func didUpdateValue()
-    func delete(control: A11yControl)
+    func delete(control: A11yControl, isUndoAvailable: Bool)
 }
 
 public class SettingsPresenter {

--- a/VoiceOver Designer/Features/Sources/Settings/SettingsViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Settings/SettingsViewController.swift
@@ -150,7 +150,7 @@ public class SettingsViewController: NSViewController {
     }
     
     @IBAction func delete(_ sender: Any) {
-        presenter.delegate?.delete(control: presenter.control)
+        presenter.delegate?.delete(control: presenter.control, isUndoAvailable: true)
         
         // TODO: Dismiss in popover presentation
 //        dismiss(self)


### PR DESCRIPTION
@akaDuality you was right here:

> Probably, the element turns back to description, but just not visible at UI

So, after a control was deleted and then restored via `CMD + Z`, it was returned to the `controls` array, but not drawed

Closes #46 