### PR TITLE
Adjustable value is added every time

### DIFF
--- a/Document/Sources/Document/Models/AdjustableOptions.swift
+++ b/Document/Sources/Document/Models/AdjustableOptions.swift
@@ -44,6 +44,7 @@ public struct AdjustableOptions: Codable {
     }
     
     public mutating func add(defaultValue: String = "") {
+        guard !options.contains(defaultValue) else { return }
         options.append(defaultValue)
         
         if currentIndex == nil, options.count > 0 {

--- a/Document/Tests/DocumentTests/AdjustableOptionsTests.swift
+++ b/Document/Tests/DocumentTests/AdjustableOptionsTests.swift
@@ -74,4 +74,21 @@ class AdjustableOptionsTests: XCTestCase {
         XCTAssertEqual(sut.currentIndex, 0)
         XCTAssertEqual(sut.currentValue, "First")
     }
+    
+    func test_addingExistingOption_shouldnotAddAdjustableOption() {
+        var sut = AdjustableOptions(options: ["First"], currentIndex: 0)
+        sut.add(defaultValue: "First")
+        XCTAssertEqual(sut.options.count, 1)
+        XCTAssertEqual(sut.currentIndex, 0)
+        XCTAssertEqual(sut.currentValue, "First")
+    }
+    
+    func test_addingMultipleEqualsOptions_shouldHaveUniqueOption() {
+        var sut = AdjustableOptions(options: [])
+        sut.add(defaultValue: "First")
+        sut.add(defaultValue: "First")
+        XCTAssertEqual(sut.options.count, 1)
+        XCTAssertEqual(sut.currentIndex, 0)
+        XCTAssertEqual(sut.currentValue, "First")
+    }
 }


### PR DESCRIPTION
# Description

This pr fixes bug described in #50

## Changes
- add check in AdjustableOptions.addAdjustableOption(defaultValue: String) for containing
- add tests for detect regression

## Screenshots

https://user-images.githubusercontent.com/36012972/181841115-ff0ae72c-950c-489c-90de-99af209229fc.mov


