### PR TITLE
Designer saves file without extension

### DIFF
--- a/Document/Sources/Document/Documents/VODesignDocument+AppKit.swift
+++ b/Document/Sources/Document/Documents/VODesignDocument+AppKit.swift
@@ -6,8 +6,10 @@ public typealias Document = NSDocument
 import os
 import Foundation
 
+
 public class VODesignDocument: Document {
     public static var vodesign = "vodesign"
+    public static var uti = "com.akaDuality.vodesign"
     
     // MARK: - Data
     public var image: Image?
@@ -109,5 +111,22 @@ public class VODesignDocument: Document {
     public static func image(from url: URL) -> Image? {
         try? ImageSaveService().load(from: url)
     }
+    public override class var readableTypes: [String] {
+        [uti]
+    }
+    public override class var writableTypes: [String] {
+        [uti]
+    }
+    public override func writableTypes(for saveOperation: NSDocument.SaveOperationType) -> [String] {
+        fileType = Self.uti
+        return super.writableTypes(for: saveOperation)
+    }
+    public override func prepareSavePanel(_ savePanel: NSSavePanel) -> Bool {
+        
+        savePanel.isExtensionHidden = false
+        return true
+    }
+    
 }
 #endif
+

--- a/Document/Tests/DocumentTests/VODesignDocumentTests.swift
+++ b/Document/Tests/DocumentTests/VODesignDocumentTests.swift
@@ -10,7 +10,20 @@ import Document
 
 #if os(macOS)
 class VODesignDocumentTests: XCTestCase {
+    override func tearDownWithError() throws {
+        try VODesignDocument.removeTestDocument(name: "TestFile")
 
+    }
+    
+    func testWhenSaveNewDocument_shouldHaveSameExtensions() throws {
+        var document: VODesignDocument? = VODesignDocument.testDocument(name: "TestFile")
+        document!.controls = [A11yDescription.testMake(label: "Label3"),
+                              A11yDescription.testMake(label: "Label4")]
+        document!.save()
+        
+        
+        XCTAssertEqual(document?.fileURL?.pathExtension, "vodesign")
+    }
 }
 
 class VODesignDocumentPersistanceTests: VODesignDocumentTests {

--- a/VoiceOver-Designer-Info.plist
+++ b/VoiceOver-Designer-Info.plist
@@ -15,6 +15,12 @@
 			<string>Editor</string>
 			<key>LSHandlerRank</key>
 			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.akaDuality.vodesign</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<true/>
 			<key>NSDocumentClass</key>
 			<string>VODesignDocument</string>
 		</dict>


### PR DESCRIPTION
# Description

this pr fixes #61 

## Changed

VODocument
- override readableTypes, writeableTypes to consume document UTI
- override writableTypes(for saveOperation: NSDocument.SaveOperationType) -> [String] to set fileExtension
- override prepareSavePanel(_ savePanel: NSSavePanel) -> Bool to show file extension