### PR TITLE
Cancel drawing operation with Esc

### DIFF
--- a/Document/Sources/Document/Drawing/Actions/Action.swift
+++ b/Document/Sources/Document/Drawing/Actions/Action.swift
@@ -3,4 +3,5 @@ import QuartzCore
 public protocol DraggingAction {
     func drag(to coordinate: CGPoint)
     func end(at coordinate: CGPoint) -> DraggingAction?
+    func cancel()
 }

--- a/Document/Sources/Document/Drawing/Actions/ClickAction.swift
+++ b/Document/Sources/Document/Drawing/Actions/ClickAction.swift
@@ -10,4 +10,8 @@ public struct ClickAction: DraggingAction {
     public func end(at coordinate: CGPoint) -> DraggingAction? {
         return self
     }
+    
+    public func cancel() {
+        
+    }
 }

--- a/Document/Sources/Document/Drawing/Actions/CopyAction.swift
+++ b/Document/Sources/Document/Drawing/Actions/CopyAction.swift
@@ -1,6 +1,12 @@
 import CoreGraphics
 
 public class CopyAction: MoveAction, DraggingAction {
+    public func cancel() {
+        control.updateWithoutAnimation {
+            control.frame = initialFrame
+        }
+    }
+    
     
     public func end(at coordinate: CGPoint) -> DraggingAction? {
         return self

--- a/Document/Sources/Document/Drawing/Actions/CopyAndTranslateAction.swift
+++ b/Document/Sources/Document/Drawing/Actions/CopyAndTranslateAction.swift
@@ -1,6 +1,14 @@
 import CoreGraphics
 
 public class CopyAndTranslateAction: DraggingAction {
+    public func cancel() {
+        if case let copy as CopyAction = action {
+            view.delete(control: copy.control)
+        }
+        
+        action?.cancel()
+    }
+    
     public func drag(to coordinate: CGPoint) {
         action?.drag(to: coordinate)
     }

--- a/Document/Sources/Document/Drawing/Actions/NewControlAction.swift
+++ b/Document/Sources/Document/Drawing/Actions/NewControlAction.swift
@@ -1,6 +1,10 @@
 import QuartzCore
 
 public class NewControlAction: DraggingAction {
+    public func cancel() {
+        view.delete(control: control)
+    }
+    
     
     init(view: DrawingView, control: A11yControl, coordinate: CGPoint) {
         self.view = view

--- a/Document/Sources/Document/Drawing/Actions/ResizeAction.swift
+++ b/Document/Sources/Document/Drawing/Actions/ResizeAction.swift
@@ -29,4 +29,10 @@ public class ResizeAction: DraggingAction {
     public func end(at coordinate: CGPoint) -> DraggingAction? {
         return self
     }
+    
+    public func cancel() {
+        control.updateWithoutAnimation {
+            control.frame = initialFrame
+        }
+    }
 }

--- a/Document/Sources/Document/Drawing/Actions/TranslateAction.swift
+++ b/Document/Sources/Document/Drawing/Actions/TranslateAction.swift
@@ -17,4 +17,8 @@ public class TranslateAction: MoveAction, DraggingAction {
     public func undo() {
         control.frame = initialFrame
     }
+    
+    public func cancel() {
+        undo()
+    }
 }

--- a/Document/Sources/Document/Drawing/Actions/TranslateAction.swift
+++ b/Document/Sources/Document/Drawing/Actions/TranslateAction.swift
@@ -19,6 +19,8 @@ public class TranslateAction: MoveAction, DraggingAction {
     }
     
     public func cancel() {
-        undo()
+        control.updateWithoutAnimation {
+            control.frame = initialFrame
+        }
     }
 }

--- a/Document/Sources/Document/Drawing/DrawingController.swift
+++ b/Document/Sources/Document/Drawing/DrawingController.swift
@@ -2,8 +2,11 @@ import CoreGraphics
 import QuartzCore
 
 public class DrawingController {
+
+    
     public init(view: DrawingView) {
         self.view = view
+        view.escListener.setDelegate(self)
         
 #if os(macOS)
         view.wantsLayer = true
@@ -76,5 +79,14 @@ public class DrawingController {
         drag(to: coordinate)
         
         return action?.end(at: coordinate)
+    }
+    
+    
+}
+
+extension DrawingController: EscModifierActionDelegate {
+    public func didPressed() {
+        action?.cancel()
+        action = nil
     }
 }

--- a/Document/Sources/Document/Drawing/DrawingView.swift
+++ b/Document/Sources/Document/Drawing/DrawingView.swift
@@ -32,6 +32,8 @@ public protocol DrawingView: View {
     var alignmentOverlay: AlignmentOverlayProtocol { get }
     
     var copyListener: CopyModifierProtocol { get }
+    
+    var escListener: EscModifierAction { get }
 }
 
 public extension DrawingView {

--- a/Document/Sources/Document/Drawing/EscCancelAction/EmptyCancelAction.swift
+++ b/Document/Sources/Document/Drawing/EscCancelAction/EmptyCancelAction.swift
@@ -1,0 +1,20 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Plotnikov on 20.08.2022.
+//
+
+import Foundation
+
+
+public class EmptyCancelAction: EscModifierAction {
+    public func setDelegate(_ delegate: EscModifierActionDelegate) {
+        self.delegate = delegate
+    }
+    
+    public var delegate: EscModifierActionDelegate?
+    
+    public init() {}
+    
+}

--- a/Document/Sources/Document/Drawing/EscCancelAction/EmptyEscModifierAction.swift
+++ b/Document/Sources/Document/Drawing/EscCancelAction/EmptyEscModifierAction.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 
-public class EmptyCancelAction: EscModifierAction {
+public class EmptyEscModifierAction: EscModifierAction {
     public func setDelegate(_ delegate: EscModifierActionDelegate) {
         self.delegate = delegate
     }

--- a/Document/Sources/Document/Drawing/EscCancelAction/EscModifierAction.swift
+++ b/Document/Sources/Document/Drawing/EscCancelAction/EscModifierAction.swift
@@ -1,0 +1,35 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Plotnikov on 20.08.2022.
+//
+
+import Foundation
+
+public class EscModifierFactory {
+    
+    public init() {
+        
+    }
+    public func make() -> EscModifierAction {
+        #if os(macOS)
+        return EscModifierActionCommand()
+        #else
+        return EmptyCancelAction()
+        #endif
+    }
+}
+
+
+public protocol EscModifierActionDelegate: AnyObject {
+    func didPressed()
+}
+
+
+public protocol EscModifierAction {
+    var delegate: EscModifierActionDelegate? { get }
+    func setDelegate(_ delegate: EscModifierActionDelegate)
+}
+
+

--- a/Document/Sources/Document/Drawing/EscCancelAction/EscModifierAction.swift
+++ b/Document/Sources/Document/Drawing/EscCancelAction/EscModifierAction.swift
@@ -16,7 +16,7 @@ public class EscModifierFactory {
         #if os(macOS)
         return EscModifierActionCommand()
         #else
-        return EmptyCancelAction()
+        return EmptyEscModifierAction()
         #endif
     }
 }

--- a/Document/Sources/Document/Drawing/EscCancelAction/EscModifierActionCommand.swift
+++ b/Document/Sources/Document/Drawing/EscCancelAction/EscModifierActionCommand.swift
@@ -1,0 +1,34 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Plotnikov on 20.08.2022.
+//
+
+import Foundation
+
+#if canImport(AppKit)
+import AppKit
+public class EscModifierActionCommand: EscModifierAction {
+    public func setDelegate(_ delegate: EscModifierActionDelegate) {
+        self.delegate = delegate
+    }
+    
+    public weak var delegate: EscModifierActionDelegate?
+    static let escapeKeyCode: UInt16 = 53
+    
+    public init() {
+        keyListener = NSEvent.addLocalMonitorForEvents(matching: [.keyDown], handler: { [weak self] event in
+            
+            if event.keyCode == Self.escapeKeyCode {
+                self?.delegate?.didPressed()
+            }
+            return event
+        })
+    }
+    
+    var keyListener: Any?
+    
+
+}
+#endif

--- a/VoiceOver Designer/Features/Sources/Editor/EditorView.swift
+++ b/VoiceOver Designer/Features/Sources/Editor/EditorView.swift
@@ -16,6 +16,8 @@ class ControlsView: FlippedView, DrawingView {
     lazy var alignmentOverlay = AlignmentOverlayFactory().overlay(for: self)
     
     var copyListener = CopyModifierFactory().make()
+    
+    var escListener = EscModifierFactory().make()
 }
 
 class EditorView: FlippedView {

--- a/VoiceOver Designer/Features/Tests/EditorTests/CancellingActionsTests.swift
+++ b/VoiceOver Designer/Features/Tests/EditorTests/CancellingActionsTests.swift
@@ -33,4 +33,58 @@ class CancellingActionsTests: EditorAfterDidLoadTests {
         XCTAssertEqual(sut.document.controls[0].frame, rect10to50)
     
     }
+    
+    func test_CancelTranslateActionShouldResetFrame() async throws {
+        
+        
+        await MainActor.run {
+            drawRect_10_60()
+        }
+        
+        // Copy
+        
+        await MainActor.run {
+            sut.mouseDown(on: .coord(15))
+            controller.controlsView.escListener.delegate?.didPressed()
+            sut.mouseUp(on: .coord(50))
+        }
+
+        
+        XCTAssertEqual(sut.document.controls.count, 1)
+        XCTAssertEqual(sut.document.controls[0].frame, rect10to50)
+    
+    }
+    
+    
+    
+    func test_CancelNewControlActionShouldDeleteNewControl() async throws {
+        
+        await MainActor.run {
+            sut.mouseDown(on: start10)
+            controller.controlsView.escListener.delegate?.didPressed()
+            sut.mouseUp(on: start10.offset(x: 10, y: 50))
+        }
+        
+        XCTAssertEqual(sut.document.controls.count, 0)
+        XCTAssertTrue(sut.document.controls.isEmpty)
+    
+    }
+    
+    
+    func test_CancelResizeActionShouldResetFrameSize() async throws {
+        drawRect(from: start10, to: end60)
+        XCTAssertEqual(drawnControls.count, 1)
+        
+        await MainActor.run {
+            sut.mouseDown(on: .coord(60-1)) // Not inclued border
+            controller.controlsView.escListener.delegate?.didPressed()
+            sut.mouseDragged(on: .coord(20))
+        }
+        
+
+        
+        XCTAssertEqual(drawnControls.count, 1)
+        XCTAssertEqual(drawnControls[0].frame, rect10to50)
+    }
+    
 }

--- a/VoiceOver Designer/Features/Tests/EditorTests/CancellingActionsTests.swift
+++ b/VoiceOver Designer/Features/Tests/EditorTests/CancellingActionsTests.swift
@@ -1,0 +1,36 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Plotnikov on 20.08.2022.
+//
+
+import Foundation
+@testable import Editor
+import XCTest
+import Document
+
+class CancellingActionsTests: EditorAfterDidLoadTests {
+    func test_CancelCopyActionShouldDeleteCopiedControlAndResetFrame() async throws {
+        let copyCommand = ManualCopyCommand()
+        
+        await MainActor.run {
+            controller.controlsView.copyListener = copyCommand
+            drawRect_10_60()
+        }
+        
+        // Copy
+        
+        await MainActor.run {
+            copyCommand.isCopyHold = true
+            sut.mouseDown(on: .coord(15))
+            controller.controlsView.escListener.delegate?.didPressed()
+            sut.mouseUp(on: .coord(50))
+        }
+
+        
+        XCTAssertEqual(sut.document.controls.count, 1)
+        XCTAssertEqual(sut.document.controls[0].frame, rect10to50)
+    
+    }
+}


### PR DESCRIPTION
# Description

This pr add handling esc button pressed on dragging action

## Changes

- added cancel() to DraggingAction and implementations for existing actions
- added EscModifierActionDelegate to trigger esc pressed action
- added EscModifierAction protocol to handle keyboard events
- added EscModifierActionCommand with keyListener
- added EmptyEscModifierAction

## TODO:

- [x] tests for canceling actions


## Screenshots

https://user-images.githubusercontent.com/36012972/185763102-974cfa53-75c1-4afe-9b1b-c28b53544b93.mov



