### PR TITLE
Image's placeholder for new document

### DIFF
--- a/VoiceOver Designer/Features/Sources/Editor/Editor.storyboard
+++ b/VoiceOver Designer/Features/Sources/Editor/Editor.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="LVp-Pr-lAJ">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -66,6 +67,17 @@
                             </scrollView>
                             <customView horizontalHuggingPriority="1" verticalHuggingPriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="dHk-Q5-FAZ" customClass="DragNDropImageView" customModule="CommonUI">
                                 <rect key="frame" x="0.0" y="0.0" width="786" height="814"/>
+                                <subviews>
+                                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Cii-yh-9Te">
+                                        <rect key="frame" x="336" y="356" width="115" height="32"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <buttonCell key="cell" type="push" title="Add Image" bezelStyle="rounded" image="plus" catalog="system" imagePosition="leading" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="exO-s4-81h">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <color key="bezelColor" name="AccentColor"/>
+                                    </button>
+                                </subviews>
                             </customView>
                         </subviews>
                         <constraints>
@@ -81,6 +93,7 @@
                             <constraint firstAttribute="bottom" secondItem="JHg-wh-ieX" secondAttribute="bottom" id="im7-2p-KCV"/>
                         </constraints>
                         <connections>
+                            <outlet property="addImageButton" destination="Cii-yh-9Te" id="Y6C-qb-AAD"/>
                             <outlet property="backgroundImageView" destination="kiH-h5-aG4" id="7f8-09-iTJ"/>
                             <outlet property="clipView" destination="lki-H1-X1O" id="yfA-nS-Iqj"/>
                             <outlet property="contentView" destination="JlK-Oy-LgO" id="6NV-jp-qGf"/>
@@ -97,4 +110,10 @@
             <point key="canvasLocation" x="-388" y="676"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="plus" catalog="system" width="14" height="13"/>
+        <namedColor name="AccentColor">
+            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/VoiceOver Designer/Features/Sources/Editor/EditorView.swift
+++ b/VoiceOver Designer/Features/Sources/Editor/EditorView.swift
@@ -31,6 +31,7 @@ class EditorView: FlippedView {
     
     @IBOutlet weak var contentView: NSView!
     @IBOutlet weak var controlsView: ControlsView!
+    @IBOutlet weak var addImageButton: NSButton!
     
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -41,6 +42,7 @@ class EditorView: FlippedView {
     
     func setImage(_ image: NSImage?) {
         dragnDropView.isHidden = image != nil
+        addImageButton.isHidden = image != nil
         
         guard let image = image else {
             return

--- a/VoiceOver Designer/Features/Sources/Editor/EditorViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Editor/EditorViewController.swift
@@ -40,6 +40,8 @@ public class EditorViewController: NSViewController {
     
     public override func viewDidAppear() {
         super.viewDidAppear()
+        view().addImageButton.action = #selector(addImageButtonTapped)
+        view().addImageButton.target = self
         DispatchQueue.main.async {
             self.presenter.didLoad(
                 ui: self.view().controlsView)
@@ -129,7 +131,27 @@ public class EditorViewController: NSViewController {
     public func delete(model: A11yDescription) {
         presenter.delete(model: model)
     }
+    
+    @objc func addImageButtonTapped() {
+        guard let window = view.window else { return }
+        let imagePanel = NSOpenPanel()
+        imagePanel.canChooseFiles = true
+        imagePanel.canChooseDirectories = false
+        imagePanel.allowsMultipleSelection = false
+        imagePanel.beginSheetModal(for: window) { [weak self] response in
+            if response == .OK {
+                if let url = imagePanel.url, let image = NSImage(contentsOf: url) {
+                    self?.presenter.update(image: image)
+                    self?.view().setImage(image)
+                    self?.view().backgroundImageView.image = image
+                    self?.presenter.save()
+                }
+            }
+        }
+    }
 }
+
+
 
 extension EditorViewController: DragNDropDelegate {
     public func didDrag(image: NSImage) {

--- a/VoiceOver Designer/Features/Sources/Editor/EditorViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Editor/EditorViewController.swift
@@ -42,12 +42,25 @@ public class EditorViewController: NSViewController {
         super.viewDidAppear()
         view().addImageButton.action = #selector(addImageButtonTapped)
         view().addImageButton.target = self
+        
         DispatchQueue.main.async {
             self.presenter.didLoad(
                 ui: self.view().controlsView)
             self.setImage()
             self.addMouseTracking()
+            self.addMenuItem()
         }
+    }
+    
+    // TODO: try to extract?
+    func addMenuItem() {
+        guard let menu = NSApplication.shared.menu, menu.item(withTitle: "Editor") == nil else { return }
+        let editorMenuItem = NSMenuItem(title: "Editor", action: nil, keyEquivalent: "")
+        let editorSubMenu = NSMenu(title: "Editor")
+        let addImageItem = NSMenuItem(title: "Add image", action: #selector(addImageButtonTapped), keyEquivalent: "")
+        editorSubMenu.addItem(addImageItem)
+        editorMenuItem.submenu = editorSubMenu
+        menu.addItem(editorMenuItem)
     }
     
     func setImage() {

--- a/VoiceOver Designer/Features/Sources/Editor/EditorViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Editor/EditorViewController.swift
@@ -146,22 +146,34 @@ public class EditorViewController: NSViewController {
     }
     
     @objc func addImageButtonTapped() {
-        guard let window = view.window else { return }
-        let imagePanel = NSOpenPanel()
-        imagePanel.canChooseFiles = true
-        imagePanel.canChooseDirectories = false
-        imagePanel.allowsMultipleSelection = false
-        imagePanel.beginSheetModal(for: window) { [weak self] response in
-            if response == .OK {
-                if let url = imagePanel.url, let image = NSImage(contentsOf: url) {
-                    self?.presenter.update(image: image)
-                    self?.view().setImage(image)
-                    self?.view().backgroundImageView.image = image
-                    self?.presenter.save()
-                }
+        Task {
+            if let image = await requestImage() {
+                presentImage(image)
             }
         }
     }
+    
+    func requestImage() async -> NSImage? {
+        guard let window = view.window else { return nil }
+        let imagePanel = NSOpenPanel()
+        imagePanel.allowedFileTypes = NSImage.imageTypes
+        imagePanel.canChooseFiles = true
+        imagePanel.canChooseDirectories = false
+        imagePanel.allowsMultipleSelection = false
+        let modalResponse = await imagePanel.beginSheetModal(for: window)
+        guard modalResponse == .OK else { return nil }
+        guard let url = imagePanel.url, let image = NSImage(contentsOf: url) else { return nil }
+        return image
+    }
+    
+    
+    func presentImage(_ image: NSImage) {
+        presenter.update(image: image)
+        view().setImage(image)
+        view().backgroundImageView.image = image
+        presenter.save()
+    }
+    
 }
 
 


### PR DESCRIPTION
# Description
This pr adds button on EditorView to open image file and save it to document. Add menu item to open file

## Changes:
- added NSButton to Editor storyboard
- added EditorViewController addImageButtonTapped() function in EditorViewController, hooked with new button
- added EditorViewController addMenuItem() to create menu item, hooked width addImageButtonTapped()

## Todo:
- [X] Create button "add image" that allows to select from Finder
- [x] Add menu item for image attachment

## Screenshots
<img width="1540" alt="Screenshot 2022-09-07 at 22 58 10" src="https://user-images.githubusercontent.com/36012972/188965843-76a1334e-6a02-453e-b0ae-9f83945efa2b.png">
