### PR TITLE
Disable undo manager on file read

### DIFF
--- a/Shared/Sources/Document/Documents/VODesignDocument+AppKit.swift
+++ b/Shared/Sources/Document/Documents/VODesignDocument+AppKit.swift
@@ -108,6 +108,8 @@ public class VODesignDocument: Document, VODesignDocumentProtocol {
     
     public override func read(from url: URL, ofType typeName: String) throws {
         Swift.print("Read from \(url)")
+        defer { undoManager?.enableUndoRegistration() }
+        undoManager?.disableUndoRegistration()
         
         controls = try DocumentSaveService(fileURL: url.appendingPathComponent("controls.json")).loadControls()
         


### PR DESCRIPTION
Closes #138 

VODesignDocument.controls has didSet closure that registers undo, but controls have default value and setted via `public func read(from url: URL, ofType typeName: String)` that undoManager records