### PR TITLE
Preview: move delete button to bottom, add Done button to top

### DIFF
--- a/VoiceOver Preview/PreviewFeatures/Sources/DesignPreview/Main/PreviewMainViewController.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/DesignPreview/Main/PreviewMainViewController.swift
@@ -71,7 +71,6 @@ public class PreviewMainViewController: UIViewController {
     private func makeView(for model: any AccessibilityView) -> some SwiftUI.View {
         let onDismiss = { [weak self] in
             guard let self else { return }
-            self.presenter.redraw(control: model)
             self.presenter.deselect()
         }
         
@@ -82,10 +81,10 @@ public class PreviewMainViewController: UIViewController {
         
         switch model {
         case let description as A11yDescription:
-            ElementSettingsView(element: description, deleteAction: onDelete)
+            ElementSettingsEditorView(element: description, delete: onDelete)
                 .onDisappear(perform: onDismiss)
         case let container as A11yContainer:
-            ContainerSettingsView(container: container)
+            ContainerSettingsEditorView(container: container, delete: onDelete)
                 .onDisappear(perform: onDismiss)
         default:
             EmptyView()

--- a/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/Components.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/Components.swift
@@ -67,7 +67,7 @@ struct EditorToolbar: ToolbarContent {
     
     private var deleteToolbarItem: some ToolbarContent {
         ToolbarItem(placement: .bottomBar, content: {
-            Button(role: .destructive, action: { isConfirmationDialogPresented = true }, label: {
+            Button(role: .destructive, action: presentDialog, label: {
                 Image(systemName: "trash")
                     .accessibilityLabel(Text("Delete"))
             })
@@ -81,9 +81,17 @@ struct EditorToolbar: ToolbarContent {
         })
     }
     
+    private func presentDialog() {
+        isConfirmationDialogPresented = true
+    }
+    
+    private func dismissDialog() {
+        isConfirmationDialogPresented = false
+    }
+    
     @ViewBuilder
     private func confirmationDialogs() -> some View {
         Button(role: .destructive, action: delete, label: {Text("Delete")})
-        Button(role: .cancel, action: { isConfirmationDialogPresented = false }, label: {Text("Cancel")})
+        Button(role: .cancel, action: dismissDialog, label: {Text("Cancel")})
     }
 }

--- a/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/Components.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/Components.swift
@@ -1,0 +1,78 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Plotnikov on 18.01.2023.
+//
+
+import SwiftUI
+
+
+struct SectionTitle: View {
+    
+    let title: LocalizedStringKey
+    
+    init(_ title: LocalizedStringKey) {
+        self.title = title
+    }
+    
+    var body: some View {
+        Text(title)
+            .font(.headline)
+    }
+}
+
+struct TextValue: View {
+    
+    let title: LocalizedStringKey
+    @Binding var value: String
+    
+    
+    public var body: some View {
+        Section(content: {
+            TextField(title, text: $value)
+        }, header: {
+            SectionTitle(title)
+        })
+    }
+}
+
+
+struct EditorToolbar: ToolbarContent {
+    var dismiss: DismissAction
+    var deleteTappedAction: () -> Void
+    
+    var body: some ToolbarContent {
+        closeToolbarItem
+        doneToolbarItem
+        deleteToolbarItem
+    }
+    
+    private var closeToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction, content: {
+            Button(action: dismiss.callAsFunction, label: {
+                Text("Close")
+            })
+        })
+    }
+    
+    private var doneToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .confirmationAction, content: {
+            Button(action: dismiss.callAsFunction, label: {
+                Text("Done")
+            })
+        })
+    }
+    
+    private var deleteToolbarItem: some ToolbarContent {
+        ToolbarItem(placement: .bottomBar, content: {
+            Button(role: .destructive, action: deleteTappedAction, label: {
+                Image(systemName: "trash")
+                    .accessibilityLabel(Text("Delete"))
+            })
+            .font(.title3)
+            .foregroundColor(.red)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+        })
+    }
+}

--- a/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/Components.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/Components.swift
@@ -39,8 +39,9 @@ struct TextValue: View {
 
 
 struct EditorToolbar: ToolbarContent {
+    @State private var isConfirmationDialogPresented = false
     var dismiss: DismissAction
-    var deleteTappedAction: () -> Void
+    var delete: () -> Void
     
     var body: some ToolbarContent {
         closeToolbarItem
@@ -66,13 +67,23 @@ struct EditorToolbar: ToolbarContent {
     
     private var deleteToolbarItem: some ToolbarContent {
         ToolbarItem(placement: .bottomBar, content: {
-            Button(role: .destructive, action: deleteTappedAction, label: {
+            Button(role: .destructive, action: { isConfirmationDialogPresented = true }, label: {
                 Image(systemName: "trash")
                     .accessibilityLabel(Text("Delete"))
             })
             .font(.title3)
             .foregroundColor(.red)
             .frame(maxWidth: .infinity, alignment: .trailing)
+            .confirmationDialog("This control will be deleted from document",
+                                isPresented: $isConfirmationDialogPresented,
+                                titleVisibility: .visible,
+                                actions: confirmationDialogs)
         })
+    }
+    
+    @ViewBuilder
+    private func confirmationDialogs() -> some View {
+        Button(role: .destructive, action: delete, label: {Text("Delete")})
+        Button(role: .cancel, action: { isConfirmationDialogPresented = false }, label: {Text("Cancel")})
     }
 }

--- a/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/ContainerSettingsView.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/ContainerSettingsView.swift
@@ -12,23 +12,14 @@ public struct ContainerSettingsEditorView: View {
         self.deleteAction = delete
     }
     
-    @State private var isConfirmationDialogPresented = false
-    
-    
     public var body: some View {
         NavigationView {
             ContainerSettingsView(container: container)
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationTitle(Text("Container"))
-                .confirmationDialog("This control will be deleted from document",
-                                    isPresented: $isConfirmationDialogPresented,
-                                    titleVisibility: .visible,
-                                    actions: confirmationDialogs)
                 .toolbar {
                     // For some reason @Environment doesn't propagate to ToolbarContent
-                    EditorToolbar(dismiss: dismiss, deleteTappedAction: {
-                        isConfirmationDialogPresented = true
-                    })
+                    EditorToolbar(dismiss: dismiss, delete: delete)
                 }
         }
         .navigationViewStyle(.stack)
@@ -37,12 +28,6 @@ public struct ContainerSettingsEditorView: View {
     private func delete() {
         deleteAction()
         dismiss()
-    }
-    
-    @ViewBuilder
-    private func confirmationDialogs() -> some View {
-        Button(role: .destructive, action: delete, label: {Text("Delete")})
-        Button(role: .cancel, action: { isConfirmationDialogPresented = false }, label: {Text("Cancel")})
     }
 }
 

--- a/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/ContainerSettingsView.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/ContainerSettingsView.swift
@@ -2,26 +2,69 @@ import Document
 import SwiftUI
 
 
-public struct ContainerSettingsView: View {
+public struct ContainerSettingsEditorView: View {
+    @Environment(\.dismiss) var dismiss
     @ObservedObject var container: A11yContainer
+    var deleteAction: () -> Void
+    
+    public init(container: A11yContainer, delete: @escaping () -> Void) {
+        self.container = container
+        self.deleteAction = delete
+    }
+    
+    @State private var isConfirmationDialogPresented = false
+    
+    
+    public var body: some View {
+        NavigationView {
+            ContainerSettingsView(container: container)
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationTitle(Text("Container"))
+                .confirmationDialog("This control will be deleted from document",
+                                    isPresented: $isConfirmationDialogPresented,
+                                    titleVisibility: .visible,
+                                    actions: confirmationDialogs)
+                .toolbar {
+                    // For some reason @Environment doesn't propagate to ToolbarContent
+                    EditorToolbar(dismiss: dismiss, deleteTappedAction: {
+                        isConfirmationDialogPresented = true
+                    })
+                }
+        }
+        .navigationViewStyle(.stack)
+    }
+    
+    private func delete() {
+        deleteAction()
+        dismiss()
+    }
+    
+    @ViewBuilder
+    private func confirmationDialogs() -> some View {
+        Button(role: .destructive, action: delete, label: {Text("Delete")})
+        Button(role: .cancel, action: { isConfirmationDialogPresented = false }, label: {Text("Cancel")})
+    }
+}
+
+
+public struct ContainerSettingsView: View {
+    
+    @ObservedObject var container: A11yContainer
+
     
     public init(container: A11yContainer) {
         self.container = container
     }
     
     public var body: some View {
-        NavigationView {
-            Form {
-                labelField
-                containerTypePicker
-                navigationStylePicker
-                optionsView
-            }
-            .navigationTitle(container.label)
+        Form {
+            Text(container.label)
+                .font(.largeTitle)
+            TextValue(title: "Label", value: $container.label)
+            containerTypePicker
+            navigationStylePicker
+            optionsView
         }
-        .navigationViewStyle(.stack)
-
-
     }
     
     private var containerTypePicker: some View {
@@ -50,18 +93,16 @@ public struct ContainerSettingsView: View {
             Toggle("Tab Section", isOn: $container.isTabTrait)
             Toggle("Enumerate elements", isOn: $container.isEnumerated)
         }, header: {
-            Text("Options")
+            SectionTitle("Options")
         })
-    }
-    
-    private var labelField: some View {
-        TextField("Label", text: $container.label)
     }
 }
 
+#if DEBUG
 struct ContainerSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        ContainerSettingsView(container: .init(elements: [], frame: .zero, label: "er"))
+        ContainerSettingsEditorView(container: .init(elements: [], frame: .zero, label: "er"), delete: {})
     }
 }
+#endif
 

--- a/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/ElementSettingsView.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/ElementSettingsView.swift
@@ -12,22 +12,14 @@ public struct ElementSettingsEditorView: View {
         self.deleteAction = delete
     }
     
-    @State private var isConfirmationDialogPresented = false
-    
-    
     public var body: some View {
         NavigationView {
             ElementSettingsView(element: element)
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationTitle(Text("Element"))
-                .confirmationDialog("This control will be deleted from document",
-                                    isPresented: $isConfirmationDialogPresented,
-                                    titleVisibility: .visible,
-                                    actions: confirmationDialogs)
+                
                 .toolbar {
-                    EditorToolbar(dismiss: dismiss, deleteTappedAction: {
-                        isConfirmationDialogPresented = true
-                    })
+                    EditorToolbar(dismiss: dismiss, delete: delete)
                 }
         }
         .navigationViewStyle(.stack)
@@ -38,11 +30,7 @@ public struct ElementSettingsEditorView: View {
         dismiss()
     }
     
-    @ViewBuilder
-    private func confirmationDialogs() -> some View {
-        Button(role: .destructive, action: delete, label: {Text("Delete")})
-        Button(role: .cancel, action: { isConfirmationDialogPresented = false }, label: {Text("Cancel")})
-    }
+
 }
 
 

--- a/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/ElementSettingsView.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/SettingsSwiftUI/ElementSettingsView.swift
@@ -2,83 +2,72 @@ import SwiftUI
 import Document
 
 
-
-public struct ElementSettingsView: View {
-    
-    @Environment(\.dismiss) private var dismissAction
+public struct ElementSettingsEditorView: View {
+    @Environment(\.dismiss) var dismiss
     @ObservedObject var element: A11yDescription
-    
     var deleteAction: () -> Void
     
-    public init(element: A11yDescription, deleteAction: @escaping () -> Void) {
+    public init(element: A11yDescription, delete: @escaping () -> Void) {
         self.element = element
-        self.deleteAction = deleteAction
+        self.deleteAction = delete
     }
+    
+    @State private var isConfirmationDialogPresented = false
+    
     
     public var body: some View {
         NavigationView {
-            Form {
-                Text(element.voiceOverText)
-                    .font(.largeTitle)
-                
-                TextValue(title: "Label", value: $element.label)
-                ValueView(value: $element.value, adjustableOptions: $element.adjustableOptions, traits: $element.trait)
-                TraitsView(selection: $element.trait)
-                
-                
-                
-                CustomActionsView(selection: $element.customActions)
-                CustomDescriptionView(selection: $element.customDescriptions)
-                TextValue(title: "Hint", value: $element.hint)
-                Toggle("Is accessible?", isOn: $element.isAccessibilityElement)
-                
-                
-            }
-            .toolbar {
-                ToolbarItem(placement: .destructiveAction, content: {
-                    Button(role: .destructive, action: delete, label: {
-                        Text("Delete")
+            ElementSettingsView(element: element)
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationTitle(Text("Element"))
+                .confirmationDialog("This control will be deleted from document",
+                                    isPresented: $isConfirmationDialogPresented,
+                                    titleVisibility: .visible,
+                                    actions: confirmationDialogs)
+                .toolbar {
+                    EditorToolbar(dismiss: dismiss, deleteTappedAction: {
+                        isConfirmationDialogPresented = true
                     })
-                    .foregroundColor(.red)
-                })
-            }
+                }
         }
         .navigationViewStyle(.stack)
     }
     
     private func delete() {
         deleteAction()
-        dismissAction()
+        dismiss()
+    }
+    
+    @ViewBuilder
+    private func confirmationDialogs() -> some View {
+        Button(role: .destructive, action: delete, label: {Text("Delete")})
+        Button(role: .cancel, action: { isConfirmationDialogPresented = false }, label: {Text("Cancel")})
     }
 }
 
-struct SectionTitle: View {
-    
-    let title: LocalizedStringKey
-    
-    init(_ title: LocalizedStringKey) {
-        self.title = title
-    }
-    
-    var body: some View {
-        Text(title)
-            .font(.headline)
-    }
-}
 
-struct TextValue: View {
+public struct ElementSettingsView: View {
+    @ObservedObject var element: A11yDescription
     
-    let title: LocalizedStringKey
-    @Binding var value: String
-    
+    public init(element: A11yDescription) {
+        self.element = element
+    }
     
     public var body: some View {
-        Section(content: {
-            TextField(title, text: $value)
-                
-        }, header: {
-            SectionTitle(title)
-        })
+        Form {
+            Text(element.voiceOverText)
+                .font(.largeTitle)
+            
+            TextValue(title: "Label", value: $element.label)
+            ValueView(value: $element.value, adjustableOptions: $element.adjustableOptions, traits: $element.trait)
+            TraitsView(selection: $element.trait)
+            
+            CustomActionsView(selection: $element.customActions)
+            CustomDescriptionView(selection: $element.customDescriptions)
+            TextValue(title: "Hint", value: $element.hint)
+            Toggle("Is accessible?", isOn: $element.isAccessibilityElement)
+            
+        }
     }
 }
 
@@ -87,9 +76,14 @@ struct TextValue: View {
 
 
 
+
+
+
+#if DEBUG
 struct ElementSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        ElementSettingsView(element: .empty(frame: .zero), deleteAction: {})
+        ElementSettingsEditorView(element: .empty(frame: .zero), delete: {})
     }
 }
+#endif
 


### PR DESCRIPTION
Closes #213 

Moved delete button to bottom bar, also add confirmation dialog to delete item

Extracted some common views, toolbar, extracted editors to potential reuse in macOS
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 00 10 45](https://user-images.githubusercontent.com/36012972/213295814-a11a40f8-f353-468c-ac1b-f22e099837c0.png)

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-19 at 00 13 03](https://user-images.githubusercontent.com/36012972/213295925-d68f8177-36f7-4c01-9e76-4221a94f5f38.png)
