### PR TITLE
Fix constraints in empty controller and settings

### DIFF
--- a/VoiceOver Designer/Features/Sources/Settings/States/Element/ElementSettingsViewController.storyboard
+++ b/VoiceOver Designer/Features/Sources/Settings/States/Element/ElementSettingsViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="6l9-zf-wkv">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="6l9-zf-wkv">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
         <capability name="NSView safe area layout guides" minToolsVersion="12.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -77,11 +77,8 @@
                             <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="251" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fBF-Lg-mkf" customClass="FlippedStackView" customModule="CanvasAppKit">
                                 <rect key="frame" x="25" y="154" width="405" height="846"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="JZg-MT-gb1">
-                                        <rect key="frame" x="-2" y="815" width="354" height="31"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="350" id="wGU-7w-KVi"/>
-                                        </constraints>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="JZg-MT-gb1">
+                                        <rect key="frame" x="-2" y="815" width="187" height="31"/>
                                         <textFieldCell key="cell" selectable="YES" title="Москва, кнопка" id="egg-Nz-KWw">
                                             <font key="font" textStyle="largeTitle" name=".SFNS-Regular"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -121,7 +118,7 @@
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="WKs-Fa-hRc">
                                         <rect key="frame" x="0.0" y="92" width="405" height="41"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nBS-l4-nDu">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nBS-l4-nDu">
                                                 <rect key="frame" x="-2" y="25" width="32" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Hint" id="eli-Tf-1Q7">
                                                     <font key="font" textStyle="headline" name=".SFNS-Bold"/>
@@ -129,7 +126,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WsT-Ca-Xcr">
+                                            <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WsT-Ca-Xcr">
                                                 <rect key="frame" x="0.0" y="0.0" width="405" height="22"/>
                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" bezelStyle="round" id="Vdr-nI-M75">
                                                     <font key="font" metaFont="system"/>

--- a/VoiceOver Designer/Features/Sources/Settings/States/Empty/EmptyViewController.storyboard
+++ b/VoiceOver Designer/Features/Sources/Settings/States/Empty/EmptyViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="bU7-R8-ocO">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="bU7-R8-ocO">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,14 +11,11 @@
             <objects>
                 <viewController id="bU7-R8-ocO" customClass="EmptyViewController" customModule="Settings" sceneMemberID="viewController">
                     <view key="view" id="tOy-S4-hL0">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="498"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="498"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qwD-jY-ObV">
-                                <rect key="frame" x="18" y="218" width="354" height="63"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="350" id="ay4-UP-NVc"/>
-                                </constraints>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qwD-jY-ObV">
+                                <rect key="frame" x="18" y="218" width="364" height="63"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" id="vNI-9Y-bA9">
                                     <font key="font" textStyle="largeTitle" name=".SFNS-Regular"/>
                                     <string key="title">Select or draw a control


### PR DESCRIPTION
Got constraint issue with width: 350 & 400. [link](https://www.wtfautolayout.com/?constraintlog=(%0A%20%20%20%20%22%3CNSLayoutConstraint:0x600003df4f00%20NSTextField:0x1497076e0.width%20%3D%3D%20350%20%20%20(active)%3E%22,%0A%20%20%20%20%22%3CNSLayoutConstraint:0x600003df5090%20NSTextField:0x1497076e0.centerX%20%3D%3D%20NSView:0x149715110.centerX%20%20%20(active)%3E%22,%0A%20%20%20%20%22%3CNSLayoutConstraint:0x600003df5130%20H:%7C-(NSSpace(20))-%5BNSTextField:0x1497076e0%5D%20%20%20(active,%20names:%20%27%7C%27:NSView:0x149715110%20)%3E%22,%0A%20%20%20%20%22%3CNSLayoutConstraint:0x600003df5270%20NSView:0x149715110.right%20%3D%3D%20NSView:0x1396c5a80.right%20%20%20(active)%3E%22,%0A%20%20%20%20%22%3CNSLayoutConstraint:0x600003df5310%20H:%7C-(0)-%5BNSView:0x149715110%5D(LTR)%20%20%20(active,%20names:%20%27%7C%27:NSView:0x1396c5a80%20)%3E%22,%0A%20%20%20%20%22%3CNSLayoutConstraint:0x600003df5360%20NSView:0x1396c5a80.width%20%3D%3D%20400%20%20%20(active)%3E%22%0A))

Fixed by removing 350 width constraints for `NSTextField`.

Settings field is already inside stackview with fill distribution, no need for constraint.

Empty view controller should just constraint to leading edge, not constraint width at all.