### PR TITLE
Remove unused constraint

### DIFF
--- a/VoiceOver Designer/Features/Sources/Settings/States/Element/ElementSettingsViewController.storyboard
+++ b/VoiceOver Designer/Features/Sources/Settings/States/Element/ElementSettingsViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="6l9-zf-wkv">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="6l9-zf-wkv">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
         <capability name="NSView safe area layout guides" minToolsVersion="12.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -68,19 +68,17 @@
             <objects>
                 <viewController id="6l9-zf-wkv" customClass="ElementSettingsViewController" customModule="Settings" sceneMemberID="viewController">
                     <view key="view" id="sJP-cf-aea" customClass="ElementSettingsView" customModule="Settings">
-                        <rect key="frame" x="0.0" y="0.0" width="455" height="1000"/>
+                        <rect key="frame" x="0.0" y="0.0" width="455" height="1038"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="251" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fBF-Lg-mkf" customClass="FlippedStackView" customModule="CanvasAppKit">
-                                <rect key="frame" x="25" y="154" width="405" height="846"/>
+                                <rect key="frame" x="25" y="0.0" width="405" height="1038"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="JZg-MT-gb1">
-                                        <rect key="frame" x="-2" y="815" width="354" height="31"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="350" id="wGU-7w-KVi"/>
-                                        </constraints>
-                                        <textFieldCell key="cell" selectable="YES" title="Москва, кнопка" id="egg-Nz-KWw">
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="JZg-MT-gb1">
+                                        <rect key="frame" x="-2" y="815" width="409" height="223"/>
+                                        <textFieldCell key="cell" selectable="YES" id="egg-Nz-KWw">
                                             <font key="font" textStyle="largeTitle" name=".SFNS-Regular"/>
+                                            <string key="title">Москва, кнопкаМосква, кнопкаМосква, кнопкаМосква, кнопкаМосква, кнопкаМосква, кнопкаМосква, кнопкаМосква, кнопкаМосква, кнопкаМосква, кнопкаМосква, кнопкаМосква, кнопка</string>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
@@ -118,7 +116,7 @@
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="WKs-Fa-hRc">
                                         <rect key="frame" x="0.0" y="92" width="405" height="41"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nBS-l4-nDu">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nBS-l4-nDu">
                                                 <rect key="frame" x="-2" y="25" width="32" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Hint" id="eli-Tf-1Q7">
                                                     <font key="font" textStyle="headline" name=".SFNS-Bold"/>
@@ -126,7 +124,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WsT-Ca-Xcr">
+                                            <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WsT-Ca-Xcr">
                                                 <rect key="frame" x="0.0" y="0.0" width="405" height="22"/>
                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" bezelStyle="round" id="Vdr-nI-M75">
                                                     <font key="font" metaFont="system"/>


### PR DESCRIPTION
Fixes constraint problem:

```
Unable to simultaneously satisfy constraints:
(
    "<NSLayoutConstraint:0x60000136b3e0 NSTextField:0x110d693c0.width == 350   (active)>",
    "<NSLayoutConstraint:0x6000013e23a0 'NSStackView.Edge.Trailing' H:[NSTextField:0x110d693c0]-(>=0)-|(LTR)   (active, names: '|':CanvasAppKit.FlippedStackView:0x110d68db0 )>",
    "<NSLayoutConstraint:0x6000013e1f40 'NSStackView.Edge.Leading' H:|-(>=0)-[NSTextField:0x110d693c0](LTR)   (active, names: '|':CanvasAppKit.FlippedStackView:0x110d68db0 )>",
    "<NSAutoresizingMaskLayoutConstraint:0x600001397890 h=-&- v=-&- NSView:0x110da3910.minX == 0   (active, names: '|':NSClipView:0x110d58a20 )>",
    "<NSAutoresizingMaskLayoutConstraint:0x6000013974d0 h=-&- v=-&- H:[NSView:0x110da3910]-(15)-|   (active, names: '|':NSClipView:0x110d58a20 )>",
    "<NSAutoresizingMaskLayoutConstraint:0x600001396850 h=-&- v=-&- NSClipView:0x110d58a20.minX == 1   (active, names: '|':NSScrollView:0x13ba57000 )>",
    "<NSAutoresizingMaskLayoutConstraint:0x600001396bc0 h=-&- v=-&- H:[NSClipView:0x110d58a20]-(1)-|   (active, names: '|':NSScrollView:0x13ba57000 )>",
    "<NSLayoutConstraint:0x60000137a3a0 Settings.ElementSettingsView:0x110d69040.right == NSView:0x110da3910.right   (active)>",
    "<NSLayoutConstraint:0x600001363c00 H:|-(0)-[Settings.ElementSettingsView:0x110d69040](LTR)   (active, names: '|':NSView:0x110da3910 )>",
    "<NSLayoutConstraint:0x60000136e210 NSScrollView:0x13ba57000.trailing == Settings.ScrollView:0x110dab790.trailing   (active)>",
    "<NSLayoutConstraint:0x60000136e710 H:|-(0)-[NSScrollView:0x13ba57000]   (active, names: '|':Settings.ScrollView:0x110dab790 )>",
    "<NSLayoutConstraint:0x60000136bb60 CanvasAppKit.FlippedStackView:0x110d68db0.centerX == Settings.ElementSettingsView:0x110d69040.centerX   (active)>",
    "<NSLayoutConstraint:0x60000136b0c0 H:|-(25)-[CanvasAppKit.FlippedStackView:0x110d68db0]   (active, names: '|':Settings.ElementSettingsView:0x110d69040 )>",
    "<NSLayoutConstraint:0x600001328a00 Settings.ScrollView:0x110dab790.right == NSView:0x13a7e7950.right   (active)>",
    "<NSLayoutConstraint:0x60000130bcf0 H:|-(0)-[Settings.ScrollView:0x110dab790](LTR)   (active, names: '|':NSView:0x13a7e7950 )>",
    "<NSLayoutConstraint:0x600001365bd0 'NSSplitViewItem.MaxSize' NSView:0x13a7e7950.width <= 400   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000136b3e0 NSTextField:0x110d693c0.width == 350   (active)>

Set the NSUserDefault NSConstraintBasedLayoutVisualizeMutuallyExclusiveConstraints to YES to have -[NSWindow visualizeConstraints:] automatically called when this happens.  And/or, set a symbolic breakpoint on LAYOUT_CONSTRAINTS_NOT_SATISFIABLE to catch this in the debugger.
```

This view is already inside a stack so it shouldn't affect whole stack width with it's width.