### PR TITLE
Remove unnecessary scale management

### DIFF
--- a/Shared/Sources/Document/Documents/Document/VODesignDocumentPresentation.swift
+++ b/Shared/Sources/Document/Documents/Document/VODesignDocumentPresentation.swift
@@ -12,10 +12,6 @@ public struct VODesignDocumentPresentation {
     public private(set) var flatControls: [A11yDescription]
     public let image: Image?
     public let imageSize: CGSize
-    public var imageSizeScaled: CGSize {
-        CGSize(width: imageSize.width / frameInfo.imageScale,
-               height: imageSize.height / frameInfo.imageScale)
-    }
     public let frameInfo: FrameInfo
 
     public init(

--- a/Shared/Sources/Document/Documents/Document/VODesignDocumentProtocol.swift
+++ b/Shared/Sources/Document/Documents/Document/VODesignDocumentProtocol.swift
@@ -30,7 +30,7 @@ extension VODesignDocumentProtocol {
 #if os(macOS)
         frameInfo.imageScale = newImage.recommendedLayerContentsScale(1)
 #elseif os(iOS)
-        frameInfo.imageScale = 1 // iOS can't exract scale information
+        frameInfo.imageScale = 1 // iOS can't extract scale information
 #endif
     }
 }

--- a/VoiceOver Designer/Features/Sources/Presentation/PresentationView.swift
+++ b/VoiceOver Designer/Features/Sources/Presentation/PresentationView.swift
@@ -356,82 +356,28 @@ extension Collection {
 
 #if DEBUG
 
-private let controls: [any AccessibilityView] = [
-    A11yContainer(
-        id: UUID(),
-        elements: [
-            A11yDescription(
-                id: UUID(),
-                isAccessibilityElement: true,
-                label: "Long long long long long long long long long long long name",
-                value: "",
-                hint: "",
-                trait: .button,
-                frame: .init(x: 100, y: 100, width: 50, height: 50),
-                adjustableOptions: .init(options: []),
-                customActions: .defaultValue
-            ),
-            A11yDescription(
-                id: UUID(),
-                isAccessibilityElement: true,
-                label: "Next element",
-                value: "25",
-                hint: "",
-                trait: .adjustable,
-                frame: .init(x: 120, y: 120, width: 60, height: 60),
-                adjustableOptions: .init(options: []),
-                customActions: .defaultValue
-            )
-        ],
-        frame: .init(x: 80, y: 80, width: 90, height: 90),
-        label: "Some container",
-        isModal: false,
-        isTabTrait: false,
-        isEnumerated: false,
-        containerType: .semanticGroup,
-        navigationStyle: .automatic
-    ),
-    A11yDescription(
-        id: UUID(),
-        isAccessibilityElement: true,
-        label: "haha",
-        value: "1",
-        hint: "Some hint",
-        trait: .adjustable,
-        frame: .init(x: 10, y: 10, width: 50, height: 50),
-        adjustableOptions: .init(options: ["1", "2"], currentIndex: 1),
-        customActions: .defaultValue
-    ),
-    A11yDescription(
-        id: UUID(),
-        isAccessibilityElement: true,
-        label: "wow",
-        value: "",
-        hint: "",
-        trait: .button,
-        frame: .init(x: 150, y: 250, width: 80, height: 20),
-        adjustableOptions: .init(options: []),
-        customActions: .defaultValue
-    )
-]
+extension PresentationView {
+    init(path: URL) {
+        let document = VODesignDocument(file: path)
+        let presentation = VODesignDocumentPresentation(document)
+        
+        self.init(document: presentation)
+    }
+    
+    static func make(sampleRelativePath: String) -> PresentationView {
+        PresentationView(path: samplesURL.appendingPathComponent(sampleRelativePath + ".vodesign"))
+    }
+}
 
-private let previewDocument = VODesignDocumentPresentation(
-    controls: controls,
-    flatControls: controls.flatMap {
-        switch $0.cast {
-            case .container(let container):
-                return container.elements
-            case .element(let element):
-                return [element]
-        }
-    },
-    image: nil,
-    imageSize: .init(width: 300, height: 300),
-    frameInfo: .default
-)
 
+let samplesURL = URL(fileURLWithPath: "/Users/mikhail/Developer/VoiceOverSamples")
 #Preview {
-    PresentationView(document: previewDocument)
+    Group {
+        PresentationView.make(sampleRelativePath: "Ru/OneTwoTrip/Главная страница")
+        PresentationView.make(sampleRelativePath: "Ru/Dodo Pizza/Меню")
+        PresentationView.make(sampleRelativePath: "Ru/OneTwoTrip/Авиа фильтры")
+        PresentationView.make(sampleRelativePath: "Ru/OneTwoTrip/Пассажиры")
+    }
 }
 
 #endif

--- a/VoiceOver Designer/Features/Sources/Presentation/PresentationView.swift
+++ b/VoiceOver Designer/Features/Sources/Presentation/PresentationView.swift
@@ -50,6 +50,7 @@ public struct PresentationView: View {
                     scroll
                 }
                 list
+                    .accessibilityHidden(true) // VoiceOver should read elements over the image
             }
         }
         .frame(

--- a/VoiceOver Designer/Features/Sources/Presentation/PresentationView.swift
+++ b/VoiceOver Designer/Features/Sources/Presentation/PresentationView.swift
@@ -26,13 +26,13 @@ public struct PresentationView: View {
     
     var minimalScaleFactor: CGFloat {
         guard 
-            document.imageSizeScaled.width != 0, 
-            document.imageSizeScaled.height != 0
+            document.imageSize.width != 0,
+            document.imageSize.height != 0
         else {
             return 1
         }
-        let h = scrollViewSize.width / document.imageSizeScaled.width
-        let v = scrollViewSize.height / document.imageSizeScaled.height
+        let h = scrollViewSize.width / document.imageSize.width
+        let v = scrollViewSize.height / document.imageSize.height
         
         // TODO: Add minimal limit for long documents
         return min(h, v)
@@ -76,8 +76,8 @@ public struct PresentationView: View {
                     controls
                 }
                 .frame(
-                    width: document.imageSizeScaled.width * minimalScaleFactor,
-                    height: document.imageSizeScaled.height * minimalScaleFactor
+                    width: document.imageSize.width * minimalScaleFactor,
+                    height: document.imageSize.height * minimalScaleFactor
                 )
                 .scaleEffect(CGSize(width: minimalScaleFactor,
                                     height: minimalScaleFactor))
@@ -90,8 +90,8 @@ public struct PresentationView: View {
             Image(nsImage: image)
                 .resizable()
                 .frame(
-                    width: document.imageSizeScaled.width,
-                    height: document.imageSizeScaled.height
+                    width: document.imageSize.width,
+                    height: document.imageSize.height
                 )
         } else {
             Color.clear

--- a/VoiceOver Preview/PreviewFeatures/Sources/CanvasUIKit/UIScrollView+Center.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/CanvasUIKit/UIScrollView+Center.swift
@@ -6,7 +6,7 @@ extension UIScrollView {
         self.contentSize = contentSize
         
         /// Fit to width for iPhone, keep image width for iPhone's screen on iPad
-        let minimalWidth = min(bounds.width, contentSize.width/UIScreen.main.scale) // Probaly scale should be got from document
+        let minimalWidth = min(bounds.width, contentSize.width)
         let scale = updateZoomScaleToFitContent(width: minimalWidth)
         
         // We had to calculate manually because first layout do it wrong

--- a/VoiceOver Preview/PreviewFeatures/Sources/DesignPreview/Main/PreviewMainViewController.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/DesignPreview/Main/PreviewMainViewController.swift
@@ -94,12 +94,12 @@ public class PreviewMainViewController: UIViewController {
     @ViewBuilder
     private func makeView(for model: any AccessibilityView) -> some SwiftUI.View {
         let onDismiss = { [weak self] in
-            guard let self else { return }
+            guard let self = self else { return }
             self.presenter.deselect()
         }
         
         let onDelete = { [weak self] in
-            guard let self else { return }
+            guard let self = self else { return }
             self.presenter.remove(model)
         }
         


### PR DESCRIPTION
OneTwoTrip samples have wrong layout according to scale.
- Updated samples to include info about image's scale
- Remove scale reducing

New files shouldn't have this problem because scale is recalculated when add an image.

Closes #288 