### PR TITLE
Fix image migration

### DIFF
--- a/VoiceOver Designer/Features/Tests/CanvasAppKitTests/ArtboardCanvasTests.swift
+++ b/VoiceOver Designer/Features/Tests/CanvasAppKitTests/ArtboardCanvasTests.swift
@@ -42,4 +42,21 @@ class ArtboardAddImageTests: CanvasAfterDidLoadTests {
         
         XCTAssertTrue(drawnFrames.isEmpty)
     }
+    
+    /// There was a bug when several images expect migration,
+    /// but the first was  `.relativeFile` and it calls `return` in migration loop instead of `break` operation,
+    /// As a result all other `.cache` images skip migration
+    func test_whenAddImageAndSave_shouldMigrateBothImageFromCache() throws {
+        sut.add(image: Sample().image3x())
+        
+        try save()
+        
+        sut.add(image: Sample().image3x())
+        
+        try save()
+    }
+    
+    private func save() throws {
+        try (sut.document as! VODesignDocument).save(name: testDocumentName, testCase: self)
+    }
 }

--- a/VoiceOver Designer/Features/Tests/CanvasAppKitTests/Base/CanvasPresenterTests.swift
+++ b/VoiceOver Designer/Features/Tests/CanvasAppKitTests/Base/CanvasPresenterTests.swift
@@ -10,19 +10,22 @@ class CanvasPresenterTests: XCTestCase {
     var document: VODesignDocumentProtocol!
     var uiScrollSpy: CanvasScrollViewSpy!
     
+    let testDocumentName = "Test"
+    
     override func setUp() {
         super.setUp()
         
         controller = EmptyViewController()
         uiScrollSpy = CanvasScrollViewSpy()
         
-        document = DocumentFake()
+        document = VODesignDocument(fileName: testDocumentName)
         
         sut = CanvasPresenter(document: document)
     }
     
     override func tearDownWithError() throws {
-        try? VODesignDocument.removeTestDocument(name: "Test")
+        // Usually a test not saves the document and there is nothing to delete
+        try? VODesignDocument.removeTestDocument(name: testDocumentName)
         document = nil
         sut = nil
         controller = nil


### PR DESCRIPTION
The bug happens on second image that expecting migration when first `relative` image breaks migration: the cycle `return` instead of `brake` operation. Move to separate function to remove possible bugs in feature.