### PR TITLE
Improve zooming

### DIFF
--- a/Shared/Sources/Canvas/CanvasPresenter.swift
+++ b/Shared/Sources/Canvas/CanvasPresenter.swift
@@ -173,8 +173,8 @@ public class CanvasPresenter: DocumentPresenter {
     }
     
     // MARK: Image
-    public func add(image: Image) {
-        add(image: image, origin: document.artboard.suggestOrigin())
+    public func add(image: Image, name: String) {
+        add(image: image, name: name, origin: document.artboard.suggestOrigin())
     }
 }
 

--- a/Shared/Sources/Canvas/CanvasPresenter.swift
+++ b/Shared/Sources/Canvas/CanvasPresenter.swift
@@ -12,30 +12,22 @@ import TextRecognition
 import Foundation
 import QuartzCore
 
-public protocol CanvasScrollViewProtocol: AnyObject {
-    func fitToWindow(animated: Bool)
-}
-
 public class CanvasPresenter: DocumentPresenter {
     
     public weak var uiContent: DrawingView!
-    public weak var uiScroll: CanvasScrollViewProtocol!
     var drawingController: DrawingController!
 
     public func didLoad(
         uiContent: DrawingView,
-        uiScroll: CanvasScrollViewProtocol,
         initialScale: CGFloat,
         previewSource: PreviewSourceProtocol
     ) {
         self.uiContent = uiContent
-        self.uiScroll = uiScroll
         self.scale = initialScale
         self.drawingController = DrawingController(view: uiContent)
         self.document.previewSource = previewSource
         
         redraw(artboard: document.artboard)
-        
     }
     
     private var scale: CGFloat = 1

--- a/Shared/Sources/Document/Accessibility/DocumentPresenter.swift
+++ b/Shared/Sources/Document/Accessibility/DocumentPresenter.swift
@@ -55,10 +55,15 @@ open class DocumentPresenter {
     }
     
     // MARK:
-    open func add(image: Image, origin: CGPoint) {
+    open func add(
+        image: Image,
+        name: String?,
+        origin: CGPoint
+    ) {
         document.invalidateQuickViewPreview()
         
         let frame = Frame(image: image,
+                          name: name,
                           frame: CGRect(origin: origin,
                                         size: image.size))
         

--- a/Shared/Sources/Document/Documents/Document/VODesignDocument+AppKit.swift
+++ b/Shared/Sources/Document/Documents/Document/VODesignDocument+AppKit.swift
@@ -49,7 +49,9 @@ public class VODesignDocument: AppleDocument, VODesignDocumentProtocol {
         
         displayName = image.name() ?? Date().description
         
-        addFrame(with: image, origin: .zero)
+        addFrame(with: image,
+                 name: image.name(),
+                 origin: .zero)
     }
     
     var version: DocumentVersion!

--- a/Shared/Sources/Document/Documents/Document/VODesignDocument+FileWrapper.swift
+++ b/Shared/Sources/Document/Documents/Document/VODesignDocument+FileWrapper.swift
@@ -231,7 +231,7 @@ extension VODesignDocumentProtocol {
         ?? CGRect(origin: .zero,
                   size: image?.size ?? defaultFrameSize) // TODO: Add image's scale
         
-        let name = frameWrapper.filename ?? UUID().uuidString
+        let name = frameWrapper.filename ?? UUID().uuidString // TODO: Remove uuidString from here
         
         return Frame(label: name,
                      imageLocation: .relativeFile(path: "Frame/\(FileName.screen)"),

--- a/Shared/Sources/Document/Documents/Document/VODesignDocumentProtocol.swift
+++ b/Shared/Sources/Document/Documents/Document/VODesignDocumentProtocol.swift
@@ -26,9 +26,11 @@ public protocol VODesignDocumentProtocol: AnyObject {
 extension VODesignDocumentProtocol {
     public func addFrame(
         with newImage: Image,
+        name: String?,
         origin: CGPoint
     ) {
         let frame = Frame(image: newImage,
+                          name: name,
                           frame: CGRect(origin: origin,
                                         size: newImage.size))
         artboard.append(frame)
@@ -87,14 +89,16 @@ public protocol PreviewSourceProtocol: AnyObject {
 }
 
 extension Frame {
-    public convenience init(image: Image, frame: CGRect) {
-        let name = UUID().uuidString // TODO: Create fancy name
-
-//        let frame = CGRect(origin: .zero, size: image.size)
+    public convenience init(
+        image: Image,
+        name: String?,
+        frame: CGRect
+    ) { 
+        let name = name ?? UUID().uuidString
         
         self.init(label: name,
                   imageLocation: .cache(image: image,
-                                        name: UUID().uuidString), // TODO: Make fancy name. Call to ChatGPT!!
+                                        name: name),
                   frame: frame,
                   elements: [])
     }

--- a/Shared/Tests/DocumentTests/Document/DocumentImage+ScaleTests.swift
+++ b/Shared/Tests/DocumentTests/Document/DocumentImage+ScaleTests.swift
@@ -46,7 +46,7 @@ final class DocumentImage_ScaleTests: XCTestCase {
     func test_APPKit_whenUpdateImageExternaly_shouldSetImageSizeWithScale() throws {
         let document = try VODesignDocument(type: uti)
         
-        document.addFrame(with: try imageWith3xScale(), origin: .zero)
+        document.addFrame(with: try imageWith3xScale(), name: "Sample", origin: .zero)
         
         let frame = try XCTUnwrap(document.artboard.frames.first)
         XCTAssertEqual(
@@ -59,7 +59,7 @@ final class DocumentImage_ScaleTests: XCTestCase {
     func test_whenAddImage_shouldCreateFrameOfImageSize() throws {
         let document = try VODesignDocument(type: uti)
         
-        document.addFrame(with: try imageWith3xScale(), origin: .zero)
+        document.addFrame(with: try imageWith3xScale(), name: "Sample", origin: .zero)
         
         let frame = try XCTUnwrap(document.artboard.frames.first, "should create frame from image")
         XCTAssertEqual(frame.frame, CGRect(origin: .zero, size: scaledSize), "should use scaled frame")

--- a/Shared/Tests/DocumentTests/Document/DocumentWrappersInvalidationTests.swift
+++ b/Shared/Tests/DocumentTests/Document/DocumentWrappersInvalidationTests.swift
@@ -15,7 +15,7 @@ class DocumentWrappersInvalidationTests: XCTestCase {
     func test_documentWithImage_whenUpdateImage_shouldInvalidateQuickLookFile() throws {
         let document = try Sample().document(name: .artboard, testCase: self)
         
-        document.addFrame(with: Image(), origin: .zero)
+        document.addFrame(with: Image(), name: "Sample", origin: .zero)
         
         XCTAssertNil(document.frameWrappers[0][FolderName.quickLook], "quickLook is invalidated")
     }

--- a/Shared/Tests/DocumentTests/Models/Order/DocumentPresenterTests+Inserting.swift
+++ b/Shared/Tests/DocumentTests/Models/Order/DocumentPresenterTests+Inserting.swift
@@ -139,7 +139,7 @@ final class DocumentPresenterTests_Inserting: XCTestCase {
     
     private func addFrameWithElement() throws {
         sut.disableUndoRegistration()
-        sut.add(image: Sample().image3x(), origin: .zero)
+        sut.add(image: Sample().image3x(), name: "Sample", origin: .zero)
         sut.append(control: A11yDescription.testMake(frame: CGRect(x: 0, y: 0, width: 20, height: 20)))
         sut.enableUndoRegistration()
     }

--- a/Shared/Tests/DocumentTests/Models/Order/DocumentPresenterTests+Movement.swift
+++ b/Shared/Tests/DocumentTests/Models/Order/DocumentPresenterTests+Movement.swift
@@ -44,7 +44,7 @@ class DocumentPresenterTests_Movement: XCTestCase {
         artboard = document.artboard
         
         sut.disableUndoRegistration()
-        sut.add(image: Sample().image3x(), origin: .zero)
+        sut.add(image: Sample().image3x(), name: "Test Frame", origin: .zero)
         
         frame = try XCTUnwrap(artboard.frames.first)
         frame.label = "Frame"
@@ -413,7 +413,7 @@ Container:
     }
     
     func test_canNotInsertFrameInFrame() throws {
-        sut.add(image: Sample().image3x(), origin: .zero)
+        sut.add(image: Sample().image3x(), name: "Sample", origin: .zero)
         let frame2 = try XCTUnwrap(artboard.frames.last)
         frame2.label = "Frame 2"
         

--- a/VoiceOver Designer/Documents/WindowManager.swift
+++ b/VoiceOver Designer/Documents/WindowManager.swift
@@ -38,14 +38,24 @@ class WindowManager: NSObject {
     private var projectController: ProjectController?
 
     func start() {
-        print("Start")
-        
+        // This method is called from applicationDidFinishLaunching
+        // This place is too early to restore any previous opened windows
+        // As a result we had to slightly wait to check what is restored
+        // In there in no other windows – show recent or new
+        //
+        // It can be fixed by finding correct place. Maybe NSApplicationDidFinishRestoringWindowsNotification will help?
+        DispatchQueue.main.async {
+            self.showRecentIfNeeded()
+        }
+    }
+    
+    private func showRecentIfNeeded() {
         if newDocumentIsCreated {
             // Document has been created from [NSDocumentController openUntitledDocumentAndDisplay:error:]
             return
         }
         if documentsPresenter.shouldShowThisController {
-            self.showRecent()
+            showRecent()
         } else {
             // TODO: Do we need it or document will open automatically?
             showNewDocument()

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/Canvas.storyboard
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/Canvas.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="LVp-Pr-lAJ">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="LVp-Pr-lAJ">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22155"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
         <capability name="NSView safe area layout guides" minToolsVersion="12.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -138,7 +138,6 @@
                         <viewLayoutGuide key="layoutMargins" id="QBA-NU-qhe"/>
                         <connections>
                             <outlet property="clipView" destination="lki-H1-X1O" id="yfA-nS-Iqj"/>
-                            <outlet property="contentView" destination="JlK-Oy-LgO" id="6NV-jp-qGf"/>
                             <outlet property="dragnDropView" destination="dHk-Q5-FAZ" id="9Yb-dX-lbU"/>
                             <outlet property="footer" destination="xXt-RS-DEx" id="CUu-m3-y9O"/>
                             <outlet property="scrollView" destination="JHg-wh-ieX" id="oB8-ia-UPa"/>

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/Canvas.storyboard
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/Canvas.storyboard
@@ -14,7 +14,7 @@
                     <view key="view" translatesAutoresizingMaskIntoConstraints="NO" id="ndy-hA-WOO" customClass="CanvasView" customModule="CanvasAppKit">
                         <rect key="frame" x="0.0" y="0.0" width="800" height="906"/>
                         <subviews>
-                            <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" allowsMagnification="YES" maxMagnification="6" minMagnification="0.01" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHg-wh-ieX" customClass="CanvasScrollView" customModule="CanvasAppKit">
+                            <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" allowsMagnification="YES" maxMagnification="6" minMagnification="0.10000000000000001" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHg-wh-ieX" customClass="CanvasScrollView" customModule="CanvasAppKit">
                                 <rect key="frame" x="0.0" y="40" width="800" height="814"/>
                                 <clipView key="contentView" drawsBackground="NO" id="lki-H1-X1O" customClass="CenteredClipView" customModule="CanvasAppKit">
                                     <rect key="frame" x="0.0" y="0.0" width="800" height="814"/>

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
@@ -29,6 +29,7 @@ class CanvasScrollView: NSScrollView {
         }
     }
     
+    // Update after any change of position or magnification
     override func reflectScrolledClipView(_ cView: NSClipView) {
         super.reflectScrolledClipView(cView)
         

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
@@ -1,9 +1,11 @@
 import AppKit
+import CommonUI
 import Canvas
 
 class CanvasScrollView: NSScrollView {
     
     weak var hud: HUDLayer?
+    weak var dragNDropImageView: DragNDropImageView?
     
     // Touch pad zooming is implemented at CanvasView
     
@@ -35,6 +37,6 @@ class CanvasScrollView: NSScrollView {
     
     private func updateHud(to magnification: CGFloat) {
         hud?.scale = 1 / magnification
+        dragNDropImageView?.scale = magnification
     }
-
 }

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
@@ -94,7 +94,7 @@ class CanvasScrollView: NSScrollView {
     }
     
     func fitToWindowIfAlreadyFitted() {
-        if isImageMagnificationFitsToWindow {
+        if imageMagnificationFitsToWindow {
             fitToWindow(animated: false)
         }
     }
@@ -110,7 +110,7 @@ class CanvasScrollView: NSScrollView {
         setMagnification(to: changed, animated: false)
     }
     
-    private var isImageMagnificationFitsToWindow: Bool {
+    private var imageMagnificationFitsToWindow: Bool {
         abs(fittingMagnification - magnification) < 0.01
     }
     

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
@@ -10,6 +10,22 @@ class CanvasScrollView: NSScrollView {
     
     weak var delegate: ScrollViewScrollingDelegate?
     
+    func documentView() -> ContentView {
+        documentView! as! ContentView
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        verticalScrollElasticity = .none
+        horizontalScrollElasticity = .none
+        
+        documentView().wantsLayer = true
+        documentView().addHUD()
+    }
+    
+    // MARK: - Zoom actions
+    
     // Touch pad zooming is implemented at CanvasView
     
     public override func scrollWheel(with event: NSEvent) {
@@ -32,10 +48,103 @@ class CanvasScrollView: NSScrollView {
         }
     }
     
+    public override func smartMagnify(with event: NSEvent) {
+        let artboardCoordinateTouch = event.location(in: documentView())
+        
+        let frame = documentView().frames.first { frameLayer in
+            frameLayer.frame.contains(artboardCoordinateTouch)
+        }
+        
+        guard let frame else {
+            fitToWindow(animated: true)
+            return
+        }
+        
+        guard !isNear(toFit: frame.frame) else {
+            fitToWindow(animated: true)
+            return
+        }
+        
+        fit(to: frame.frame,
+            animated: true)
+    }
+    
+    // MARK: Delegates
+    
     // Update after any change of position or magnification
     override func reflectScrolledClipView(_ cView: NSClipView) {
         super.reflectScrolledClipView(cView)
         
         delegate?.didUpdateScale(magnification)
+    }
+    
+    // MARK: Custom zooming
+    func fittingMagnification(bounds: CGRect) -> CGFloat {
+        let fittingMagnification = (frame.size / bounds.size).min()
+        
+        let limited = (minMagnification...maxMagnification).trim(fittingMagnification)
+        
+        return limited
+    }
+    
+    private var fittingMagnification: CGFloat {
+        let contentBounds = documentView().boundingBox
+        
+        return fittingMagnification(bounds: contentBounds)
+    }
+    
+    func fitToWindowIfAlreadyFitted() {
+        if isImageMagnificationFitsToWindow {
+            fitToWindow(animated: false)
+        }
+    }
+    
+    func fitToWindow(animated: Bool) {
+        let contentBounds = documentView().boundingBox
+        
+        fit(to: contentBounds, animated: animated)
+    }
+    
+    func changeMagnification(_ change: (_ current: CGFloat) -> CGFloat) {
+        let changed = change(magnification)
+        setMagnification(to: changed, animated: false)
+    }
+    
+    private var isImageMagnificationFitsToWindow: Bool {
+        abs(fittingMagnification - magnification) < 0.01
+    }
+    
+    private func setMagnification(
+        to magnification: CGFloat,
+        center: CGPoint? = nil,
+        animated: Bool
+    ) {
+        let center = center
+        ?? documentView().hud.selectedControlFrame?.center
+        ?? documentView().frame.center
+        
+        (animated ? animator() : self).setMagnification(
+            magnification,
+            centeredAt: center)
+    }
+    
+    private func isNear(toFit bounds: CGRect) -> Bool {
+        let fittingMagnification = fittingMagnification(bounds: bounds)
+        
+        let isNear = abs(magnification - fittingMagnification) < 0.1
+        return isNear
+    }
+    
+    private func fit(to bounds: CGRect, animated: Bool) {
+        animator().magnify(toFit: bounds)
+    }
+}
+
+extension ClosedRange where Bound == CGFloat {
+    fileprivate func trim(_ value: Bound) -> Bound {
+        Swift.max(
+            lowerBound,
+            Swift.min(upperBound, value)
+        )
     }
 }

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
@@ -2,13 +2,13 @@ import AppKit
 import CommonUI
 import Canvas
 
-protocol ScrollViewScrollingDelegate: AnyObject {
+protocol ScrollViewZoomDelegate: AnyObject {
     func didUpdateScale(_ magnification: CGFloat)
 }
 
 class CanvasScrollView: NSScrollView {
     
-    weak var delegate: ScrollViewScrollingDelegate?
+    weak var delegate: ScrollViewZoomDelegate?
     
     func documentView() -> ContentView {
         documentView! as! ContentView

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
@@ -27,13 +27,14 @@ class CanvasScrollView: NSScrollView {
         }
     }
     
-    override func setMagnification(_ magnification: CGFloat, centeredAt point: NSPoint) {
-        super.setMagnification(magnification, centeredAt: point)
+    override func reflectScrolledClipView(_ cView: NSClipView) {
+        super.reflectScrolledClipView(cView)
         
         updateHud(to: magnification)
     }
     
-    func updateHud(to magnification: CGFloat) {
+    private func updateHud(to magnification: CGFloat) {
         hud?.scale = 1 / magnification
     }
+
 }

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
@@ -2,10 +2,13 @@ import AppKit
 import CommonUI
 import Canvas
 
+protocol ScrollViewScrollingDelegate: AnyObject {
+    func didUpdateScale(_ magnification: CGFloat)
+}
+
 class CanvasScrollView: NSScrollView {
     
-    weak var hud: HUDLayer?
-    weak var dragNDropImageView: DragNDropImageView?
+    weak var delegate: ScrollViewScrollingDelegate?
     
     // Touch pad zooming is implemented at CanvasView
     
@@ -33,11 +36,6 @@ class CanvasScrollView: NSScrollView {
     override func reflectScrolledClipView(_ cView: NSClipView) {
         super.reflectScrolledClipView(cView)
         
-        updateHud(to: magnification)
-    }
-    
-    private func updateHud(to magnification: CGFloat) {
-        hud?.scale = 1 / magnification
-        dragNDropImageView?.scale = magnification
+        delegate?.didUpdateScale(magnification)
     }
 }

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasScrollView.swift
@@ -5,10 +5,15 @@ class CanvasScrollView: NSScrollView {
     
     weak var hud: HUDLayer?
     
+    // Touch pad zooming is implemented at CanvasView
+    
     public override func scrollWheel(with event: NSEvent) {
         let isCommandPressed = event.modifierFlags.contains(.command)
         
-        guard isCommandPressed else {
+        let isTrackpad = !event.hasPreciseScrollingDeltas
+        let canScroll = isTrackpad || isCommandPressed // Command changes mouse behaviour from pan to scroll
+        
+        guard canScroll else {
             super.scrollWheel(with: event)
             return
         }

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView+Zoom.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView+Zoom.swift
@@ -3,105 +3,19 @@ import AppKit
 
 extension CanvasView {
     
-    // Scroll wheel function is implemented at CanvasScrollView
-    
     public override func magnify(with event: NSEvent) {
-        // TODO: This forwarding is strange.
-        // Looks like scrollView should be firstResponder automatically
         scrollView.magnify(with: event)
     }
     
     public override func smartMagnify(with event: NSEvent) {
-        let artboardCoordinateTouch = event.location(in: contentView)
-        
-        let frame = contentView.frames.first { frameLayer in
-            frameLayer.frame.contains(artboardCoordinateTouch)
-        }
-        
-        guard let frame else {
-            fitToWindow(animated: true)
-            return
-        }
-        
-        guard !isNear(toFit: frame.frame) else {
-            fitToWindow(animated: true)
-            return
-        }
-        
-        fit(to: frame.frame,
-            animated: true)
+        scrollView.smartMagnify(with: event)
     }
 }
 
 extension CanvasView: CanvasScrollViewProtocol {
     
     func fitToWindow(animated: Bool) {
-        let contentBounds = contentView.boundingBox
-        
-        fit(to: contentBounds, animated: animated)
-    }
-    
-    func isNear(toFit bounds: CGRect) -> Bool {
-        let fittingMagnification = fittingMagnification(bounds: bounds)
-        
-        let isNear = abs(scrollView.magnification - fittingMagnification) < 0.1
-        return isNear
-    }
-    
-    func fit(to bounds: CGRect, animated: Bool) {
-        scrollView.animator().magnify(toFit: bounds)
-    }
-    
-    func fitToWindowIfAlreadyFitted() {
-        if isImageMagnificationFitsToWindow {
-            fitToWindow(animated: false)
-        }
-    }
-    
-    func changeMagnification(_ change: (_ current: CGFloat) -> CGFloat) {
-        let current = scrollView.magnification
-        let changed = change(current)
-        setMagnification(to: changed, animated: false)
-    }
-    
-    private func setMagnification(
-        to magnification: CGFloat,
-        center: CGPoint? = nil,
-        animated: Bool
-    ) {
-        // Manually trim to keep value to sync with hud
-        let newLevel = (scrollView.minMagnification...scrollView.maxMagnification).trim(magnification)
-        
-        let scrollView = animated ? scrollView.animator() : scrollView
-
-        dragnDropView.scale = newLevel
-        
-        let center = center
-        ?? contentView.hud.selectedControlFrame?.center
-        ?? contentView.frame.center
-        
-        scrollView?.setMagnification(
-            magnification,
-            centeredAt: center)
-    }
-    
-    private var isImageMagnificationFitsToWindow: Bool {
-        abs(fittingMagnification - scrollView.magnification) < 0.01
-    }
-    
-    private var fittingMagnification: CGFloat {
-        let contentBounds = contentView.boundingBox
-
-        return fittingMagnification(bounds: contentBounds)
-    }
-    
-    private func fittingMagnification(bounds: CGRect) -> CGFloat {
-        let fittingMagnification = (scrollView.frame.size
-                                    / bounds.size).min()
-        
-        let limited = (scrollView.minMagnification...scrollView.maxMagnification).trim(fittingMagnification)
-        
-        return limited
+        scrollView.fitToWindow(animated: animated)
     }
 }
 
@@ -148,11 +62,3 @@ extension CGPoint {
     }
 }
 
-extension ClosedRange where Bound == CGFloat {
-    fileprivate func trim(_ value: Bound) -> Bound {
-        Swift.max(
-            lowerBound,
-            Swift.min(upperBound, value)
-        )
-    }
-}

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView+Zoom.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView+Zoom.swift
@@ -1,0 +1,126 @@
+import Canvas
+import AppKit
+
+extension CanvasView: CanvasScrollViewProtocol {
+    func fitToWindow(animated: Bool) {
+        let contentBounds = contentView.boundingBox
+        
+        let fittingMagnification = fittingMagnification // Calculate once
+        
+        let originOffsetToCenter = (contentBounds.size - scrollView.frame.size / fittingMagnification) / 2
+        
+        let center = contentBounds.origin + originOffsetToCenter.point()
+        
+        scrollView.contentView.scroll(to: center)
+        
+        setMagnification(to: fittingMagnification,
+                         center: center,
+                         animated: animated)
+    }
+    
+    func fitToWindowIfAlreadyFitted() {
+        if isImageMagnificationFitsToWindow {
+            fitToWindow(animated: false)
+        }
+    }
+    
+    func changeMagnification(_ change: (_ current: CGFloat) -> CGFloat) {
+        let current = scrollView.magnification
+        let changed = change(current)
+        setMagnification(to: changed, animated: false)
+    }
+    
+    private func setMagnification(
+        to magnification: CGFloat,
+        center: CGPoint? = nil,
+        animated: Bool
+    ) {
+        // Manually trim to keep value in sync with real limitation
+        let newLevel = (scrollView.minMagnification...scrollView.maxMagnification).trim(magnification)
+        
+        var scrollView = self.scrollView
+        if animated {
+            scrollView = self.scrollView.animator()
+            
+            self.scrollView.updateHud(to: newLevel) // Animator calls another function
+        }
+        
+        dragnDropView.scale = newLevel
+        
+        let center = center
+        ?? contentView.hud.selectedControlFrame?.center
+        ?? contentView.frame.center
+        
+        scrollView?.setMagnification(
+            newLevel,
+            centeredAt: center)
+    }
+    
+    private var isImageMagnificationFitsToWindow: Bool {
+        abs(fittingMagnification - scrollView.magnification) < 0.01
+    }
+    
+    private var fittingMagnification: CGFloat {
+        let contentBounds = contentView.boundingBox
+
+        let fittingMagnification = (scrollView.frame.size
+                                    / contentBounds.size).min()
+        
+        let limited = (scrollView.minMagnification...scrollView.maxMagnification).trim(fittingMagnification)
+        
+        return limited
+    }
+
+}
+
+extension CGSize {
+    static func /(_ lhs: Self, _ divider: CGFloat) -> Self {
+        precondition(divider != 0, "Can't divide by zero")
+        
+        return Self(width: lhs.width/divider,
+                    height: lhs.height/divider)
+    }
+    
+    static func -(_ lhs: Self, _ rhs: Self) -> Self {
+        Self(width: lhs.width - rhs.width,
+             height: lhs.height - rhs.height)
+    }
+    
+    static func /(_ lhs: Self, _ rhs: Self) -> Self {
+        precondition(rhs.width != 0, "Can't divide by zero X")
+        precondition(rhs.height != 0, "Can't divide by zero Y")
+        
+        return Self(width:  lhs.width/rhs.width,
+                    height: lhs.height/rhs.height)
+    }
+    
+    func point() -> CGPoint {
+        CGPoint(x: width, y: height)
+    }
+    
+    
+    func min() -> CGFloat {
+        Swift.min(width, height)
+    }
+}
+
+extension CGPoint {
+    
+    static func +(_ lhs: Self, _ rhs: Self) -> Self {
+        Self(x:  lhs.x + rhs.x,
+             y: lhs.y + rhs.y)
+    }
+    
+    func min() -> CGFloat {
+        Swift.min(x, y)
+    }
+}
+
+extension ClosedRange where Bound == CGFloat {
+    fileprivate func trim(_ value: Bound) -> Bound {
+        Swift.max(
+            lowerBound,
+            Swift.min(upperBound, value)
+        )
+    }
+}

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView+Zoom.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView+Zoom.swift
@@ -12,13 +12,6 @@ extension CanvasView {
     }
 }
 
-extension CanvasView: CanvasScrollViewProtocol {
-    
-    func fitToWindow(animated: Bool) {
-        scrollView.fitToWindow(animated: animated)
-    }
-}
-
 extension CGSize {
     static func /(_ lhs: Self, _ divider: CGFloat) -> Self {
         precondition(divider != 0, "Can't divide by zero")

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
@@ -17,7 +17,9 @@ class CanvasView: FlippedView {
     
     @IBOutlet weak var clipView: NSClipView!
     
-    @IBOutlet weak var contentView: ContentView!
+    var documentView: ContentView {
+        scrollView.documentView()
+    }
    
     @IBOutlet weak var dragnDropView: DragNDropImageView!
     
@@ -30,12 +32,7 @@ class CanvasView: FlippedView {
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        scrollView.verticalScrollElasticity = .none
-        scrollView.horizontalScrollElasticity = .none
         scrollView.delegate = self
-        
-        contentView.wantsLayer = true
-        contentView.addHUD()
         
         zoomOutButton.toolTip = "⌘-"
         zoomToFitButton.toolTip = "0"
@@ -47,7 +44,7 @@ class CanvasView: FlippedView {
         dragnDropView.hideTextAndBorder()
         
         clipView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.translatesAutoresizingMaskIntoConstraints = false
+        documentView.translatesAutoresizingMaskIntoConstraints = false
     }
     
     var isEmpty: Bool = true {
@@ -72,13 +69,13 @@ class CanvasView: FlippedView {
     }
     
     func image(at frame: CGRect) async -> CGImage? {
-        contentView.image(at: frame)
+        documentView.image(at: frame)
     }
     
     func control(
         for model: any ArtboardElement
     ) -> A11yControlLayer? {
-        contentView
+        documentView
             .drawnControls
             .first(where: { control in
                 control.model === model
@@ -88,14 +85,14 @@ class CanvasView: FlippedView {
 
 extension CanvasView: ScrollViewScrollingDelegate {
     func didUpdateScale(_ magnification: CGFloat) {
-        contentView.hud.scale = 1 / magnification
+        documentView.hud.scale = 1 / magnification
         dragnDropView.scale = magnification
     }
 }
 
 extension CanvasView: PreviewSourceProtocol {
     func previewImage() -> Image? {
-        contentView.imageRepresentation()
+        documentView.imageRepresentation()
     }
 }
 

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
@@ -83,7 +83,7 @@ class CanvasView: FlippedView {
     }
 }
 
-extension CanvasView: ScrollViewScrollingDelegate {
+extension CanvasView: ScrollViewZoomDelegate {
     func didUpdateScale(_ magnification: CGFloat) {
         documentView.hud.scale = 1 / magnification
         dragnDropView.scale = magnification

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
@@ -33,6 +33,7 @@ class CanvasView: FlippedView {
         scrollView.verticalScrollElasticity = .none
         scrollView.horizontalScrollElasticity = .none
         scrollView.hud = contentView.hud
+        scrollView.dragNDropImageView = dragnDropView
         contentView.wantsLayer = true
         contentView.addHUD()
         

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
@@ -58,59 +58,7 @@ class CanvasView: FlippedView {
             }
         }
     }
-    
-    // MARK: - Magnification
-    func fitToWindowIfAlreadyFitted() {
-        if isImageMagnificationFitsToWindow {
-            fitToWindow(animated: false)
-        }
-    }
-    
-    func changeMagnifacation(_ change: (_ current: CGFloat) -> CGFloat) {
-        let current = scrollView.magnification
-        let changed = change(current)
-        setMagnification(to: changed, animated: false)
-    }
-    
-    private func setMagnification(to magnification: CGFloat, animated: Bool) {
-        // Manually trim to keep value in sync with real limitation
-        let newLevel = (scrollView.minMagnification...scrollView.maxMagnification).trim(magnification)
         
-        var scrollView = self.scrollView
-        if animated {
-            scrollView = self.scrollView.animator()
-            
-            self.scrollView.updateHud(to: newLevel) // Animator calls another function
-        }
-        
-        dragnDropView.scale = newLevel
-        
-        let center = contentView.hud.selectedControlFrame?.center ?? contentView.frame.center
-        
-        scrollView?.setMagnification(
-            newLevel,
-            centeredAt: center)
-    }
-    
-    private var isImageMagnificationFitsToWindow: Bool {
-        if let fittingMagnification {
-            return abs(fittingMagnification - scrollView.magnification) < 0.01
-        } else {
-            return false
-        }
-    }
-    
-    private var fittingMagnification: CGFloat? {
-        let contentSize = contentView.intrinsicContentSize
-        
-        let insetScale: CGFloat = 1
-        let sizeWithOffset = CGSize(width: contentSize.width * insetScale,
-                                    height: contentSize.height * insetScale)
-        
-        return min(scrollView.frame.height / sizeWithOffset.height,
-                   scrollView.frame.width / sizeWithOffset.width)
-    }
-    
     // MARK: - Image
     func updateDragnDropVisibility(hasDrawnControls: Bool) {
         if hasDrawnControls {
@@ -134,14 +82,6 @@ class CanvasView: FlippedView {
             .first(where: { control in
                 control.model === model
             })
-    }
-}
-
-extension CanvasView: CanvasScrollViewProtocol {
-    func fitToWindow(animated: Bool) {
-        if let fittingMagnification {
-            setMagnification(to: fittingMagnification, animated: animated)
-        }
     }
 }
 
@@ -178,14 +118,5 @@ extension NSEdgeInsets {
 extension CGRect {
     var center: CGPoint {
         CGPoint(x: midX, y: midY)
-    }
-}
-
-extension ClosedRange where Bound == CGFloat {
-    fileprivate func trim(_ value: Bound) -> Bound {
-        Swift.max(
-            lowerBound,
-            Swift.min(upperBound, value)
-        )
     }
 }

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
@@ -15,7 +15,7 @@ class CanvasView: FlippedView {
     
     @IBOutlet weak var scrollView: CanvasScrollView!
     
-    @IBOutlet weak var clipView: NSClipView!
+    @IBOutlet weak var clipView: CenteredClipView!
     
     var documentView: ContentView {
         scrollView.documentView()
@@ -87,6 +87,7 @@ extension CanvasView: ScrollViewScrollingDelegate {
     func didUpdateScale(_ magnification: CGFloat) {
         documentView.hud.scale = 1 / magnification
         dragnDropView.scale = magnification
+        clipView.magnification = magnification
     }
 }
 
@@ -117,6 +118,10 @@ extension NSView {
 extension NSEdgeInsets {
     var verticals: CGFloat {
         top + bottom
+    }
+    
+    var horizontals: CGFloat {
+        left + right
     }
 }
 

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasView.swift
@@ -32,8 +32,8 @@ class CanvasView: FlippedView {
         
         scrollView.verticalScrollElasticity = .none
         scrollView.horizontalScrollElasticity = .none
-        scrollView.hud = contentView.hud
-        scrollView.dragNDropImageView = dragnDropView
+        scrollView.delegate = self
+        
         contentView.wantsLayer = true
         contentView.addHUD()
         
@@ -83,6 +83,13 @@ class CanvasView: FlippedView {
             .first(where: { control in
                 control.model === model
             })
+    }
+}
+
+extension CanvasView: ScrollViewScrollingDelegate {
+    func didUpdateScale(_ magnification: CGFloat) {
+        contentView.hud.scale = 1 / magnification
+        dragnDropView.scale = magnification
     }
 }
 

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
@@ -168,7 +168,7 @@ public class CanvasViewController: NSViewController {
         Task {
             if let path = await requestImage(),
                let image = NSImage(contentsOf: path) {
-                presenter.add(image: image)
+                presenter.add(image: image, name: path.lastPathComponent)
             }
         }
     }
@@ -238,10 +238,12 @@ extension CanvasViewController: NSWindowDelegate {
 }
 
 extension CanvasViewController: DragNDropDelegate {
-    public func didDrag(image: NSImage, locationInWindow: CGPoint) {
+    public func didDrag(image: NSImage, locationInWindow: CGPoint, name: String?) {
         let locationInCanvas = view().contentView.convert(locationInWindow, from: nil)
         let shouldAnimate = presenter.document.artboard.frames.count != 0
-        presenter.add(image: image, origin: locationInCanvas)
+        presenter.add(image: image,
+                      name: name,
+                      origin: locationInCanvas)
         view().fitToWindow(animated: shouldAnimate)
     }
     

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
@@ -34,7 +34,7 @@ public class CanvasViewController: NSViewController {
         
         view.window?.delegate = self
         
-        presenter.didLoad(uiContent: view().contentView,
+        presenter.didLoad(uiContent: view().documentView,
                           uiScroll: view(),
                           initialScale: 1,
                           previewSource: view())
@@ -110,7 +110,7 @@ public class CanvasViewController: NSViewController {
     var highlightedControl: A11yControlLayer?
     
     private func location(from event: NSEvent) -> CGPoint {
-        event.location(in: view().contentView)
+        event.location(in: view().documentView)
     }
     
     // MARK: - Mouse movement
@@ -215,32 +215,39 @@ extension CanvasViewController {
     }
     
     @IBAction func reduceMagnifing(sender: Any) {
-        view().changeMagnification { current in
+        view().scrollView.changeMagnification { current in
             current / zoomStep
         }
     }
     
     @IBAction func increaseMagnifing(sender: Any) {
-        view().changeMagnification { current in
+        view().scrollView.changeMagnification { current in
             current * zoomStep
         }
     }
     
     @IBAction func fitMagnifing(sender: Any) {
-        view().fitToWindow(animated: true)
+        view().scrollView.fitToWindow(animated: true)
     }
 }
 
 extension CanvasViewController: NSWindowDelegate {
     public func windowDidResize(_ notification: Notification) {
-        view().fitToWindowIfAlreadyFitted()
+        view().scrollView.fitToWindowIfAlreadyFitted()
     }
 }
 
 extension CanvasViewController: DragNDropDelegate {
-    public func didDrag(image: NSImage, locationInWindow: CGPoint, name: String?) {
-        let locationInCanvas = view().contentView.convert(locationInWindow, from: nil)
+    public func didDrag(
+        image: NSImage,
+        locationInWindow: CGPoint,
+        name: String?
+    ) {
+        let locationInCanvas = view().documentView
+            .convert(locationInWindow, from: nil)
+        
         let shouldAnimate = presenter.document.artboard.frames.count != 0
+        
         presenter.add(image: image,
                       name: name,
                       origin: locationInCanvas)

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
@@ -35,7 +35,6 @@ public class CanvasViewController: NSViewController {
         view.window?.delegate = self
         
         presenter.didLoad(uiContent: view().documentView,
-                          uiScroll: view(),
                           initialScale: 1,
                           previewSource: view())
         
@@ -52,7 +51,7 @@ public class CanvasViewController: NSViewController {
         observe()
         
         // Zoom after layout of scrollView
-        view().fitToWindow(animated: false)
+        view().scrollView.fitToWindow(animated: false)
     }
     
     public override func viewWillDisappear() {
@@ -251,7 +250,7 @@ extension CanvasViewController: DragNDropDelegate {
         presenter.add(image: image,
                       name: name,
                       origin: locationInCanvas)
-        view().fitToWindow(animated: shouldAnimate)
+        view().scrollView.fitToWindow(animated: shouldAnimate)
     }
     
     public func didDrag(path: URL) -> Bool {

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
@@ -215,13 +215,13 @@ extension CanvasViewController {
     }
     
     @IBAction func reduceMagnifing(sender: Any) {
-        view().changeMagnifacation { current in
+        view().changeMagnification { current in
             current / zoomStep
         }
     }
     
     @IBAction func increaseMagnifing(sender: Any) {
-        view().changeMagnifacation { current in
+        view().changeMagnification { current in
             current * zoomStep
         }
     }

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CanvasViewController.swift
@@ -49,9 +49,6 @@ public class CanvasViewController: NSViewController {
         
         presenter.subscribeOnControlChanges()
         observe()
-        
-        // Zoom after layout of scrollView
-        view().scrollView.fitToWindow(animated: false)
     }
     
     public override func viewWillDisappear() {

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CenteredClipView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CenteredClipView.swift
@@ -2,24 +2,25 @@ import AppKit
 
 class CenteredClipView: NSClipView
 {
-//    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
-//        var rect = super.constrainBoundsRect(proposedBounds)
-//        
-//        if let containerView = documentView {
-//            let containerSize = containerView.intrinsicContentSize // can change on current layout pass and have not yet affect just containerView.frame
-//            
-//            if (rect.size.width > containerSize.width) {
-//                rect.origin.x = (containerSize.width - rect.width) / 2
-//            }
-//            
-//            if(rect.size.height > containerSize.height) {
-//                rect.origin.y = (containerSize.height - rect.height) / 2
-//            }
-//        }
-//        
-//        return rect
-//    }
+    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
+        var rect = super.constrainBoundsRect(proposedBounds)
+        
+        if let containerView = documentView {
+            let containerSize = containerView.intrinsicContentSize // can change on current layout pass and have not yet affect just containerView.frame
+            
+            if (rect.size.width > containerSize.width) {
+                rect.origin.x = (containerSize.width - rect.width) / 2
+            }
+            
+            if(rect.size.height > containerSize.height) {
+                rect.origin.y = (containerSize.height - rect.height) / 2
+            }
+        }
+        
+        return rect
+    }
     
+    // TODO: Set from another place
     override var contentInsets: NSEdgeInsets {
         get {
             let inset: CGFloat = 5000

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CenteredClipView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CenteredClipView.swift
@@ -1,36 +1,30 @@
 import AppKit
 
-class CenteredClipView: NSClipView
-{
-    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
-        var rect = super.constrainBoundsRect(proposedBounds)
-        
-        if let containerView = documentView {
-            let containerSize = containerView.intrinsicContentSize // can change on current layout pass and have not yet affect just containerView.frame
-            
-            if (rect.size.width > containerSize.width) {
-                rect.origin.x = (containerSize.width - rect.width) / 2
-            }
-            
-            if(rect.size.height > containerSize.height) {
-                rect.origin.y = (containerSize.height - rect.height) / 2
-            }
-        }
-        
-        return rect
-    }
+class CenteredClipView: NSClipView {
     
-    // TODO: Set from another place
+    var magnification: CGFloat = 1
+    
+    /// In document's coordinate space
     override var contentInsets: NSEdgeInsets {
         get {
-            let inset: CGFloat = 5000
-            return NSEdgeInsets(
-                top: inset,
-                left: inset,
-                bottom: inset,
-                right: inset)
+            let contentSize = documentView!.intrinsicContentSize
+            
+            guard contentSize.width != .infinity && contentSize.height != .infinity
+            else { return NSEdgeInsetsZero }
+            
+            let horizontal = max(0, (frame.width  / magnification - contentSize.width ))
+            let vertical   = max(0, (frame.height / magnification - contentSize.height))
+            
+            let insets = NSEdgeInsets(
+                top: vertical,
+                left: horizontal,
+                bottom: vertical,
+                right: horizontal)
+            
+            return insets
         }
         
         set {}
     }
 }
+

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CenteredClipView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CenteredClipView.swift
@@ -24,7 +24,7 @@ class CenteredClipView: NSClipView {
             return insets
         }
         
-        set {}
+        set {} // Self-managed insets for correct scrolling
     }
 }
 

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/CenteredClipView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/CenteredClipView.swift
@@ -2,21 +2,34 @@ import AppKit
 
 class CenteredClipView: NSClipView
 {
-    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
-        var rect = super.constrainBoundsRect(proposedBounds)
-        
-        if let containerView = documentView {
-            let containerSize = containerView.intrinsicContentSize // can change on current layout pass and have not yet affect just containerView.frame
-            
-            if (rect.size.width > containerSize.width) {
-                rect.origin.x = (containerSize.width - rect.width) / 2
-            }
-            
-            if(rect.size.height > containerSize.height) {
-                rect.origin.y = (containerSize.height - rect.height) / 2
-            }
+//    override func constrainBoundsRect(_ proposedBounds: NSRect) -> NSRect {
+//        var rect = super.constrainBoundsRect(proposedBounds)
+//        
+//        if let containerView = documentView {
+//            let containerSize = containerView.intrinsicContentSize // can change on current layout pass and have not yet affect just containerView.frame
+//            
+//            if (rect.size.width > containerSize.width) {
+//                rect.origin.x = (containerSize.width - rect.width) / 2
+//            }
+//            
+//            if(rect.size.height > containerSize.height) {
+//                rect.origin.y = (containerSize.height - rect.height) / 2
+//            }
+//        }
+//        
+//        return rect
+//    }
+    
+    override var contentInsets: NSEdgeInsets {
+        get {
+            let inset: CGFloat = 5000
+            return NSEdgeInsets(
+                top: inset,
+                left: inset,
+                bottom: inset,
+                right: inset)
         }
         
-        return rect
+        set {}
     }
 }

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/ContentView.swift
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/ContentView.swift
@@ -22,8 +22,7 @@ class ContentView: FlippedView, DrawingView {
 
     // MARK: - Images
     override var intrinsicContentSize: NSSize {
-        NSSize(width:  -boundingBox.origin.x + boundingBox.size.width,
-               height: boundingBox.origin.y + boundingBox.size.height)
+        boundingBox.size
     }
     
     private var defaultBoundingBox: CGRect {
@@ -32,7 +31,7 @@ class ContentView: FlippedView, DrawingView {
             size: CGSize(width: 800, height: 400)) // TODO: Understaned default size
     }
     
-    private var boundingBox: CGRect {
+    var boundingBox: CGRect {
         guard let sublayers = layer?
             .sublayers?.filter({ layer in
                 !(layer is HUDLayer) // Skip HudLayer

--- a/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
+++ b/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
@@ -8,7 +8,7 @@
 import AppKit
 
 public protocol DragNDropDelegate: AnyObject {
-    func didDrag(image: NSImage, locationInWindow: CGPoint)
+    func didDrag(image: NSImage, locationInWindow: CGPoint, name: String?)
     func didDrag(path: URL) -> Bool
 }
 
@@ -137,7 +137,9 @@ open class DragNDropImageView: NSView {
         let pasteboard = sender.draggingPasteboard
         
         if let image = sender.image() {
-            delegate?.didDrag(image: image, locationInWindow: sender.draggingLocation)
+            delegate?.didDrag(image: image,
+                              locationInWindow: sender.draggingLocation,
+                              name: pasteboard.fileName)
             hideTextAndBorder()
             return true
         }
@@ -243,9 +245,22 @@ extension CGSize {
     }
 }
 
-// TODO: Remove duplication
+// TODO: Remove duplicationString(data: , encoding: .utf8)
 extension NSEvent {
     func location(in view: NSView) -> CGPoint {
         view.convert(locationInWindow, from: nil)
+    }
+}
+
+extension NSPasteboard {
+    var fileName: String? {
+        guard let data = data(forType: .fileURL),
+              let string = String(data: data, encoding: .utf8),
+              let url = URL(string: string) else {
+            return nil
+        }
+        
+        return url.lastPathComponent
+        
     }
 }

--- a/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
+++ b/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
@@ -110,6 +110,7 @@ open class DragNDropImageView: NSView {
         imageSize = sender.image()?.size
         isWaitingForFile = true
         hideText()
+        showBorder()
         return .copy
     }
     
@@ -165,9 +166,13 @@ open class DragNDropImageView: NSView {
         show(text: defaultText)
     }
     
+    private func showBorder() {
+        border.isHidden = false
+    }
+    
     func show(text: String, changeTo nextText: String? = nil) {
         label.isHidden = false
-        border.isHidden = false
+        showBorder()
         self.text = text
         
         if let nextText = nextText {

--- a/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.swift
@@ -68,7 +68,7 @@ extension DocumentsBrowserViewController: DragNDropDelegate {
         return true
     }
     
-    public func didDrag(image: NSImage, locationInWindow: CGPoint) {
+    public func didDrag(image: NSImage, locationInWindow: CGPoint, name: String?) {
         let document = VODesignDocument(image: image)
         show(document: document)
     }

--- a/VoiceOver Designer/Features/Tests/CanvasAppKitTests/Base/CanvasPresenterTests.swift
+++ b/VoiceOver Designer/Features/Tests/CanvasAppKitTests/Base/CanvasPresenterTests.swift
@@ -8,7 +8,6 @@ class CanvasPresenterTests: XCTestCase {
     var sut: CanvasPresenter!
     var controller: EmptyViewController!
     var document: VODesignDocumentProtocol!
-    var uiScrollSpy: CanvasScrollViewSpy!
     
     let testDocumentName = "Test"
     
@@ -16,7 +15,6 @@ class CanvasPresenterTests: XCTestCase {
         super.setUp()
         
         controller = EmptyViewController()
-        uiScrollSpy = CanvasScrollViewSpy()
         
         document = VODesignDocument(fileName: testDocumentName)
         
@@ -69,7 +67,6 @@ extension CanvasPresenterTests {
     
     func didLoad() {
         sut.didLoad(uiContent: controller.controlsView,
-                    uiScroll: uiScrollSpy,
                     initialScale: 1,
                     previewSource: PreviewSourceDummy())
     }
@@ -138,12 +135,6 @@ extension CanvasPresenter {
 class PreviewSourceDummy: PreviewSourceProtocol {
     func previewImage() -> Image? {
         nil
-    }
-}
-
-class CanvasScrollViewSpy: CanvasScrollViewProtocol {
-    func fitToWindow(animated: Bool) {
-        
     }
 }
 

--- a/VoiceOver Designer/Features/Tests/CanvasAppKitTests/Base/CanvasPresenterTests.swift
+++ b/VoiceOver Designer/Features/Tests/CanvasAppKitTests/Base/CanvasPresenterTests.swift
@@ -146,3 +146,9 @@ class CanvasScrollViewSpy: CanvasScrollViewProtocol {
         
     }
 }
+
+extension CanvasPresenter {
+    func add(image: NSImage) {
+        add(image: image, name: "Sample")
+    }
+}

--- a/VoiceOver Designer/Features/Tests/CanvasAppKitTests/NewDrawingTests.swift
+++ b/VoiceOver Designer/Features/Tests/CanvasAppKitTests/NewDrawingTests.swift
@@ -89,7 +89,7 @@ class NewDrawingTests: CanvasAfterDidLoadTests {
     
     func addFrame() {
         let image = Sample().image3x()
-        sut.add(image: image)
+        sut.add(image: image, name: "Sample")
     }
     
     // MARK: - Frame drawing

--- a/VoiceOver Preview/PreviewFeatures/Sources/CanvasUIKit/ScrollView.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/CanvasUIKit/ScrollView.swift
@@ -45,7 +45,6 @@ class ScrollView: UIView {
 
 extension ScrollView: UIScrollViewDelegate {
 
-
     func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         if let elements = container.accessibilityElements {
             layout?.updateContainers(in: elements)

--- a/VoiceOver Preview/PreviewFeatures/Sources/CanvasUIKit/VODesignPreviewViewController.swift
+++ b/VoiceOver Preview/PreviewFeatures/Sources/CanvasUIKit/VODesignPreviewViewController.swift
@@ -57,7 +57,6 @@ extension VODesignPreviewViewController {
         view().controls = frame?.elements ?? []
         presenter.didLoad(
             uiContent: view().canvas,
-            uiScroll: self,
             initialScale: 1,
             previewSource: view())
     }
@@ -125,11 +124,5 @@ extension VODesignPreviewViewController {
         @unknown default:
             break
         }
-    }
-}
-
-extension VODesignPreviewViewController: CanvasScrollViewProtocol {
-    public func fitToWindow(animated: Bool) {
-        // TODO: Do we need something here?
     }
 }


### PR DESCRIPTION
Closes #319 

- [x] Add big insets to free space for additional frames
- [x] "Fit" button should place all frames in center of document
- Fix zooming by touchpad
   - [x] Can zoom by pinch
   - [x] Can double tap touchpad for smart zoom
      - [x] Can show all frames if already zoomed on one of the frames
   - [x] CMD-scroll should zoom by mouse
   - [x] Can swipe by two fingers on touchpad (Also calls scrollWheel, but don't requires holden CMD

### Fixed bugs
- [x] Outline is not drawn during drag'n'drop
   - [x] Refactor links to hud and drag'n'drop view at CanvasScrollView
- [x] Samples window opens every launch
- [x] Top and left inset are weird. Refactor as a result: not center, but add correct insets
