### PR TITLE
Remove samples screen on launch

### DIFF
--- a/VoiceOver Designer.xcodeproj/project.pbxproj
+++ b/VoiceOver Designer.xcodeproj/project.pbxproj
@@ -628,7 +628,7 @@
 				CODE_SIGN_ENTITLEMENTS = "VoiceOver Designer/VoiceOver_Designer.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 25;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = P67Q4Q7HA9;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -642,7 +642,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.akaDuality.VoiceOver-Designer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -659,7 +659,7 @@
 				CODE_SIGN_ENTITLEMENTS = "VoiceOver Designer/VoiceOver DesignerRelease.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 25;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = P67Q4Q7HA9;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -673,7 +673,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.akaDuality.VoiceOver-Designer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -802,7 +802,7 @@
 				CODE_SIGN_ENTITLEMENTS = "VoiceOver Designer/VoiceOver DesignerRelease.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 25;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = P67Q4Q7HA9;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -816,7 +816,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 2.0;
+				MARKETING_VERSION = 2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.akaDuality.VoiceOver-Designer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/VoiceOver Designer/AppDelegate.swift
+++ b/VoiceOver Designer/AppDelegate.swift
@@ -56,5 +56,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         windowManager.createNewDocumentWindow(document: document)
     }
+    
+    @IBAction @objc func openSample(_ sender: Any) {
+        // TODO: Should be simplified
+        
+        let languageButton = NSApplication.shared.keyWindow?.toolbar?.items.first(where: { item in
+            item.itemIdentifier == NSToolbarItem.Identifier(rawValue: "SamplesButtonLabel")
+        })
+        
+        guard let languageButton else { return }
+        
+        windowManager.showSamples(languageButton)
+    }
 }
 

--- a/VoiceOver Designer/AppDelegate.swift
+++ b/VoiceOver Designer/AppDelegate.swift
@@ -16,9 +16,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let isDefaultLaunch = aNotification.userInfo?[NSApplication.launchIsDefaultUserInfoKey] as? Bool ?? false
         
         print("Is default launch \(isDefaultLaunch)")
-        
-        windowManager.start()
-        
 #if DEBUG
         openFileForUITestIfNeeded()
         
@@ -58,10 +55,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             document = VODesignDocument(image: image)
         }
         windowManager.createNewDocumentWindow(document: document)
-    }
-    
-    func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool {
-        false
     }
 }
 

--- a/VoiceOver Designer/AppDelegate.swift
+++ b/VoiceOver Designer/AppDelegate.swift
@@ -31,7 +31,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        true
+        // Sometimes the app opens from dock without UI
+        // When user creates new document this method has been called before the new window it appeared
+        // As a result the apps is closed because there is the window *haven't been opened yet*
+        // It looks like apple's bug.
+        return false
     }
     
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {

--- a/VoiceOver Designer/AppDelegate.swift
+++ b/VoiceOver Designer/AppDelegate.swift
@@ -54,7 +54,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let image = NSImage(byReferencing: url)
             document = VODesignDocument(image: image)
         }
-        windowManager.createNewDocumentWindow(document: document)
+        windowManager.show(document: document)
     }
     
     @IBAction @objc func openSample(_ sender: Any) {

--- a/VoiceOver Designer/Documents/VODesignDocument+Window.swift
+++ b/VoiceOver Designer/Documents/VODesignDocument+Window.swift
@@ -3,6 +3,6 @@ import Document
 extension VODesignDocument {
     public override func makeWindowControllers() {
         WindowManager.shared
-            .createNewDocumentWindow(document: self)
+            .show(document: self)
     }
 }

--- a/VoiceOver Designer/Documents/WindowManager.swift
+++ b/VoiceOver Designer/Documents/WindowManager.swift
@@ -28,7 +28,7 @@ class WindowManager: NSObject {
     
     lazy var rootWindowController: RecentWindowController = {
         let windowController = RecentWindowController()
-        windowController.delegate = self
+        windowController.router = self
         windowController.presenter = documentsPresenter
         
         return windowController
@@ -46,11 +46,8 @@ class WindowManager: NSObject {
     private weak var presentedPopover: NSPopover?
 }
 
-extension WindowManager: RecentDelegate {
-    
-    func createNewDocumentWindow(
-        document: VODesignDocument
-    ) {
+extension WindowManager: RecentRouter {
+    func show(document: VODesignDocument) {
         print("will open \(document.fileURL?.absoluteString ?? "Unknown fileURL")")
         
         // TODO: Check that this document is not opened in another tab
@@ -95,7 +92,7 @@ extension WindowManager: ProjectRouterDelegate {
             self.presentedPopover = nil // Should be cleared automatically, but release manually for feature possible bugs
             return
         }
-        let controller = DocumentsTabViewController(router: rootWindowController, selectedTab: type)
+        let controller = DocumentsTabViewController(router: self, selectedTab: type)
         controller.preferredContentSize = CGSize(width: 1000, height: 800)
         
         let window = NSApplication.shared.keyWindow!

--- a/VoiceOver Designer/Documents/WindowManager.swift
+++ b/VoiceOver Designer/Documents/WindowManager.swift
@@ -82,7 +82,6 @@ extension WindowManager: ProjectRouterDelegate {
         showDocument(sender, type: .samples)
     }
     
-
     func showRecent(_ sender: NSToolbarItem) {
         showDocument(sender, type: .recent)
     }

--- a/VoiceOver Designer/Documents/WindowManager.swift
+++ b/VoiceOver Designer/Documents/WindowManager.swift
@@ -6,35 +6,6 @@ import SwiftUI
 class WindowManager: NSObject {
     
     static var shared = WindowManager()
-    
-    let documentsPresenter = SamplesDocumentsPresenter.shared
-    
-    func makeRecentWindow() -> NSWindow {
-        let controller = DocumentsTabViewController(router: rootWindowController, selectedTab: .recent)
-        let window = NSWindow(contentViewController: controller)
-        
-        window.toolbar = controller.toolbar()
-        
-        prepare(window)
-        
-        window.minSize = CGSize(width: 800, height: 700) // Two rows, 5 columns
-        window.isRestorable = false
-        window.titlebarAppearsTransparent = false
-        
-        rootWindowController.window = window
-
-        return window
-    }
-    
-    lazy var rootWindowController: RecentWindowController = {
-        let windowController = RecentWindowController()
-        windowController.router = self
-        windowController.presenter = documentsPresenter
-        
-        return windowController
-    }()
-    
-    private var projectController: ProjectController?
 
     func prepare(_ window: NSWindow) {
         window.tabbingMode = .preferred

--- a/VoiceOver Designer/Documents/WindowManager.swift
+++ b/VoiceOver Designer/Documents/WindowManager.swift
@@ -42,6 +42,8 @@ class WindowManager: NSObject {
         window.setFrameAutosaveName("Projects")
         window.styleMask = [.closable, .miniaturizable, .resizable, .titled, .fullSizeContentView]
     }
+    
+    private weak var presentedPopover: NSPopover?
 }
 
 extension WindowManager: RecentDelegate {
@@ -87,6 +89,12 @@ extension WindowManager: ProjectRouterDelegate {
     }
     
     private func showDocument(_ sender: NSToolbarItem, type: DocumentsTabViewController.SelectedTab) {
+        if let presentedPopover {
+            // Hide presented controller and not present the new one
+            presentedPopover.close()
+            self.presentedPopover = nil // Should be cleared automatically, but release manually for feature possible bugs
+            return
+        }
         let controller = DocumentsTabViewController(router: rootWindowController, selectedTab: type)
         controller.preferredContentSize = CGSize(width: 1000, height: 800)
         
@@ -98,6 +106,8 @@ extension WindowManager: ProjectRouterDelegate {
             popover.contentViewController = controller
             popover.behavior = .transient
             popover.show(relativeTo: sender)
+            
+            self.presentedPopover = popover
         } else {
             contentController.present(
                 controller,
@@ -116,14 +126,5 @@ private final class WindowWithCancel: NSWindow {
     // https://stackoverflow.com/a/42440020
     @objc func cancel(_ sender: Any?) {
         contentViewController?.cancelOperation(sender)
-    }
-    
-    /// Handle toolbar action by window
-    @objc private func selectLanguage(sender: NSMenuItem) {
-        let languageSource: LanguageSource = SamplesDocumentsPresenter.shared
-        
-        let languageCode = languageSource.possibleLanguages[sender.tag]
-        
-        languageSource.samplesLanguage = languageCode
     }
 }

--- a/VoiceOver Designer/Documents/WindowManager.swift
+++ b/VoiceOver Designer/Documents/WindowManager.swift
@@ -38,9 +38,9 @@ extension WindowManager: RecentRouter {
     
     func addTabOrCreateWindow(with window: NSWindow) {
         let application = NSApplication.shared
-        if let keyWindow = application.keyWindow {
-            keyWindow.tabGroup?.addWindow(window)
-            keyWindow.tabGroup?.selectedWindow = window
+        if let tabGroup = application.keyWindow?.tabGroup {
+            tabGroup.addWindow(window)
+            tabGroup.selectedWindow = window
         } else {
             window.makeKeyAndOrderFront(self)
         }

--- a/VoiceOver Designer/Documents/WindowManager.swift
+++ b/VoiceOver Designer/Documents/WindowManager.swift
@@ -7,7 +7,7 @@ class WindowManager: NSObject {
     
     static var shared = WindowManager()
     
-    let documentsPresenter = DocumentPresenterFactory().presenter()
+    let documentsPresenter = SamplesDocumentsPresenter.shared
     
     func makeRecentWindow() -> NSWindow {
         let controller = DocumentsTabViewController(router: rootWindowController, selectedTab: .recent)
@@ -109,11 +109,21 @@ extension WindowManager: ProjectRouterDelegate {
     }
 }
 
+import Samples
 private final class WindowWithCancel: NSWindow {
 
     // Should be cancelOperation, but macos has a bug. cancelOperation(sender:) doesn't work, this does.
     // https://stackoverflow.com/a/42440020
     @objc func cancel(_ sender: Any?) {
         contentViewController?.cancelOperation(sender)
+    }
+    
+    /// Handle toolbar action by window
+    @objc private func selectLanguage(sender: NSMenuItem) {
+        let languageSource: LanguageSource = SamplesDocumentsPresenter.shared
+        
+        let languageCode = languageSource.possibleLanguages[sender.tag]
+        
+        languageSource.samplesLanguage = languageCode
     }
 }

--- a/VoiceOver Designer/Features/Sources/CanvasAppKit/Canvas.storyboard
+++ b/VoiceOver Designer/Features/Sources/CanvasAppKit/Canvas.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="LVp-Pr-lAJ">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="LVp-Pr-lAJ">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="NSView safe area layout guides" minToolsVersion="12.0"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -59,21 +59,66 @@
                             <customView horizontalHuggingPriority="1" verticalHuggingPriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="dHk-Q5-FAZ" customClass="DragNDropImageView" customModule="CommonUI">
                                 <rect key="frame" x="0.0" y="0.0" width="800" height="906"/>
                                 <subviews>
-                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Cii-yh-9Te">
-                                        <rect key="frame" x="344" y="383" width="113" height="40"/>
-                                        <buttonCell key="cell" type="push" title="Add Image" bezelStyle="rounded" image="plus" catalog="system" imagePosition="leading" alignment="center" controlSize="large" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="exO-s4-81h">
-                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
-                                        </buttonCell>
-                                        <color key="bezelColor" name="AccentColor"/>
-                                    </button>
+                                    <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="24" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bw8-nF-5ZQ">
+                                        <rect key="frame" x="218" y="403" width="364" height="100"/>
+                                        <subviews>
+                                            <button imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s5V-1C-nkW">
+                                                <rect key="frame" x="-3" y="-4" width="176" height="107"/>
+                                                <buttonCell key="cell" type="bevel" title="Open sample" bezelStyle="regularSquare" imagePosition="left" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="KaL-wD-pPQ">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="system"/>
+                                                    <imageReference key="image" image="graduationcap" catalog="system" symbolScale="large"/>
+                                                </buttonCell>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="170" id="ZdP-L2-mBm"/>
+                                                    <constraint firstAttribute="height" constant="100" id="hrJ-VV-xoI"/>
+                                                </constraints>
+                                                <connections>
+                                                    <action selector="openSample:" target="Wlo-hV-FCI" id="6ZX-Fi-5eM"/>
+                                                </connections>
+                                            </button>
+                                            <button imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Cii-yh-9Te">
+                                                <rect key="frame" x="191" y="-4" width="176" height="107"/>
+                                                <buttonCell key="cell" type="bevel" title="Add Screenshot" bezelStyle="regularSquare" imagePosition="leading" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="exO-s4-81h">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" textStyle="body" name=".SFNS-Regular"/>
+                                                    <imageReference key="image" image="photo.artframe" catalog="system" symbolScale="large"/>
+                                                </buttonCell>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="Cii-yh-9Te" firstAttribute="width" secondItem="s5V-1C-nkW" secondAttribute="width" id="tl4-JJ-Ngm"/>
+                                            <constraint firstItem="Cii-yh-9Te" firstAttribute="height" secondItem="s5V-1C-nkW" secondAttribute="height" id="vLg-36-iAf"/>
+                                        </constraints>
+                                        <visibilityPriorities>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                        </visibilityPriorities>
+                                        <customSpacing>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                        </customSpacing>
+                                    </stackView>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IO7-aa-92P">
+                                        <rect key="frame" x="452" y="379" width="91" height="16"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" title="or drag'n'drop" id="yeX-aX-UCe">
+                                            <font key="font" usesAppearanceFont="YES"/>
+                                            <color key="textColor" name="tertiaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="Cii-yh-9Te" firstAttribute="centerX" secondItem="dHk-Q5-FAZ" secondAttribute="centerX" id="8MI-I4-pht"/>
+                                    <constraint firstItem="IO7-aa-92P" firstAttribute="centerX" secondItem="Cii-yh-9Te" secondAttribute="centerX" id="5zq-wy-xnp"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="400" id="LKl-HZ-UDo"/>
-                                    <constraint firstItem="Cii-yh-9Te" firstAttribute="centerY" secondItem="dHk-Q5-FAZ" secondAttribute="centerY" constant="50" id="oQf-Yq-to2"/>
+                                    <constraint firstItem="Bw8-nF-5ZQ" firstAttribute="centerY" secondItem="dHk-Q5-FAZ" secondAttribute="centerY" id="N86-1h-pVh"/>
+                                    <constraint firstItem="IO7-aa-92P" firstAttribute="top" secondItem="Cii-yh-9Te" secondAttribute="bottom" constant="8" id="PZl-Qz-aSG"/>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="814" id="pTM-t9-HL8"/>
+                                    <constraint firstItem="Bw8-nF-5ZQ" firstAttribute="centerX" secondItem="dHk-Q5-FAZ" secondAttribute="centerX" id="wuy-2E-cFn"/>
                                 </constraints>
+                                <connections>
+                                    <outlet property="dragndropHere" destination="IO7-aa-92P" id="fLq-vi-iaU"/>
+                                </connections>
                             </customView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="xXt-RS-DEx">
                                 <rect key="frame" x="0.0" y="0.0" width="800" height="40"/>
@@ -81,7 +126,7 @@
                                     <stackView distribution="fill" orientation="horizontal" alignment="top" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mCV-f8-hTw">
                                         <rect key="frame" x="596" y="10" width="184" height="20"/>
                                         <subviews>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hlp-qk-Lzc">
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hlp-qk-Lzc">
                                                 <rect key="frame" x="-2" y="2" width="50" height="14"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="⌘+scroll" id="q7H-rP-QxS">
                                                     <font key="font" metaFont="smallSystem"/>
@@ -103,14 +148,14 @@
                                             </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5ma-Hm-fQo">
                                                 <rect key="frame" x="91" y="-4" width="56" height="27"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="hqe-62-P3Z"/>
-                                                </constraints>
                                                 <buttonCell key="cell" type="bevel" title="Fit" bezelStyle="regularSquare" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="0qr-8q-RNS">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                     <string key="keyEquivalent">0</string>
                                                 </buttonCell>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="hqe-62-P3Z"/>
+                                                </constraints>
                                                 <connections>
                                                     <action selector="fitMagnifingWithSender:" target="LVp-Pr-lAJ" id="6th-eu-hdq"/>
                                                 </connections>
@@ -188,11 +233,9 @@
         </scene>
     </scenes>
     <resources>
+        <image name="graduationcap" catalog="system" width="27" height="23"/>
         <image name="minus.magnifyingglass" catalog="system" width="16" height="15"/>
-        <image name="plus" catalog="system" width="14" height="13"/>
+        <image name="photo.artframe" catalog="system" width="24" height="18"/>
         <image name="plus.magnifyingglass" catalog="system" width="16" height="15"/>
-        <namedColor name="AccentColor">
-            <color red="0.0" green="0.46000000000000002" blue="0.89000000000000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
     </resources>
 </document>

--- a/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
+++ b/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
@@ -17,20 +17,6 @@ open class DragNDropImageView: NSView {
     
     public weak var delegate: DragNDropDelegate?
 
-    lazy var samplesHint: NSTextField = {
-        let label = NSTextField(string: "↑ Samples!")
-        label.font = NSFont.preferredFont(forTextStyle: .largeTitle)
-        label.textColor = .tertiaryLabelColor
-        label.backgroundColor = .clear
-        label.isBordered = false
-        
-        addSubview(label)
-        label.isEditable = false
-        label.isSelectable = false
-        label.alignment = .center
-        return label
-    }()
-    
     lazy var dragndropHere: NSTextField = {
         let label = NSTextField(string: defaultText)
         label.font = NSFont.preferredFont(forTextStyle: .body)
@@ -60,13 +46,6 @@ open class DragNDropImageView: NSView {
     
     open override func layout() {
         super.layout()
-        
-        samplesHint.sizeToFit()
-        let hintSize = samplesHint.frame.size
-        samplesHint.frame = CGRect(
-            origin: CGPoint(x: 75,
-                            y: bounds.height - hintSize.height - 70),
-            size: hintSize)
         
         dragndropHere.sizeToFit()
         let size = dragndropHere.frame.size

--- a/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
+++ b/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
@@ -17,23 +17,11 @@ open class DragNDropImageView: NSView {
     
     public weak var delegate: DragNDropDelegate?
 
-    lazy var dragndropHere: NSTextField = {
-        let label = NSTextField(string: defaultText)
-        label.font = NSFont.preferredFont(forTextStyle: .body)
-        label.textColor = .tertiaryLabelColor
-        label.backgroundColor = .clear
-        label.isBordered = false
-        
-        addSubview(label)
-        label.isEditable = false
-        label.isSelectable = false
-        label.alignment = .center
-        return label
-    }()
+    @IBOutlet weak var dragndropHere: NSTextField?
     
     var text: String = "" {
         didSet {
-            dragndropHere.stringValue = text
+            dragndropHere?.stringValue = text
             needsLayout = true
         }
     }
@@ -43,18 +31,6 @@ open class DragNDropImageView: NSView {
         
         registerDragging()
     }
-    
-    open override func layout() {
-        super.layout()
-        
-        dragndropHere.sizeToFit()
-        let size = dragndropHere.frame.size
-        dragndropHere.frame = CGRect(
-            origin: CGPoint(x: (bounds.width-size.width)/2,
-                            y: (bounds.height-size.height)/2-80),
-            size: size)
-    }
-
     
     // MARK: - Dragging
     func registerDragging() {
@@ -103,7 +79,7 @@ open class DragNDropImageView: NSView {
     let defaultText = NSLocalizedString("or Drag'n'Drop", comment: "")
     
     func show(text: String, changeTo nextText: String? = nil) {
-        dragndropHere.isHidden = false
+        dragndropHere?.isHidden = false
         self.text = text
         
         if let nextText = nextText {
@@ -114,6 +90,6 @@ open class DragNDropImageView: NSView {
     }
     
     func hideText() {
-        dragndropHere.isHidden = true
+        dragndropHere?.isHidden = true
     }
 }

--- a/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
+++ b/VoiceOver Designer/Features/Sources/CommonUI/DragNDropImageView.swift
@@ -17,9 +17,23 @@ open class DragNDropImageView: NSView {
     
     public weak var delegate: DragNDropDelegate?
 
-    lazy var label: NSTextField = {
-        let label = NSTextField(string: defaultText)
+    lazy var samplesHint: NSTextField = {
+        let label = NSTextField(string: "↑ Samples!")
         label.font = NSFont.preferredFont(forTextStyle: .largeTitle)
+        label.textColor = .tertiaryLabelColor
+        label.backgroundColor = .clear
+        label.isBordered = false
+        
+        addSubview(label)
+        label.isEditable = false
+        label.isSelectable = false
+        label.alignment = .center
+        return label
+    }()
+    
+    lazy var dragndropHere: NSTextField = {
+        let label = NSTextField(string: defaultText)
+        label.font = NSFont.preferredFont(forTextStyle: .body)
         label.textColor = .tertiaryLabelColor
         label.backgroundColor = .clear
         label.isBordered = false
@@ -33,7 +47,7 @@ open class DragNDropImageView: NSView {
     
     var text: String = "" {
         didSet {
-            label.stringValue = text
+            dragndropHere.stringValue = text
             needsLayout = true
         }
     }
@@ -47,11 +61,18 @@ open class DragNDropImageView: NSView {
     open override func layout() {
         super.layout()
         
-        label.sizeToFit()
-        let size = label.frame.size
-        label.frame = CGRect(
+        samplesHint.sizeToFit()
+        let hintSize = samplesHint.frame.size
+        samplesHint.frame = CGRect(
+            origin: CGPoint(x: 75,
+                            y: bounds.height - hintSize.height - 70),
+            size: hintSize)
+        
+        dragndropHere.sizeToFit()
+        let size = dragndropHere.frame.size
+        dragndropHere.frame = CGRect(
             origin: CGPoint(x: (bounds.width-size.width)/2,
-                            y: (bounds.height-size.height)/2),
+                            y: (bounds.height-size.height)/2-80),
             size: size)
     }
 
@@ -100,10 +121,10 @@ open class DragNDropImageView: NSView {
         return false
     }
     
-    let defaultText = NSLocalizedString("Drag'n'Drop image here", comment: "")
+    let defaultText = NSLocalizedString("or Drag'n'Drop", comment: "")
     
     func show(text: String, changeTo nextText: String? = nil) {
-        label.isHidden = false
+        dragndropHere.isHidden = false
         self.text = text
         
         if let nextText = nextText {
@@ -114,6 +135,6 @@ open class DragNDropImageView: NSView {
     }
     
     func hideText() {
-        label.isHidden = true
+        dragndropHere.isHidden = true
     }
 }

--- a/VoiceOver Designer/Features/Sources/Recent/DocumentsTabViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/DocumentsTabViewController.swift
@@ -3,7 +3,12 @@ import Document // For @Storage
 
 public class DocumentsTabViewController: NSTabViewController {
     
-    public init(router: RecentRouter) {
+    public enum SelectedTab: Int {
+        case recent = 0
+        case samples = 1
+    }
+    
+    public init(router: RecentRouter, selectedTab: SelectedTab) {
         super.init(nibName: nil, bundle: nil)
         
         let documentsController = documentsBrowserController(presenter: UserDocumentsPresenter(), router: router)
@@ -24,7 +29,7 @@ public class DocumentsTabViewController: NSTabViewController {
         addTabViewItem(samplesTab)
         
         tabStyle = .unspecified
-        selectedTabViewItemIndex = Self.lastSelectedTabIndex
+        selectedTabViewItemIndex = selectedTab.rawValue// Self.lastSelectedTabIndex
     }
     
     required init?(coder: NSCoder) {

--- a/VoiceOver Designer/Features/Sources/Recent/DocumentsTabViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/DocumentsTabViewController.swift
@@ -180,8 +180,16 @@ public class LanguageButton: NSMenuToolbarItem {
         
         super.init(itemIdentifier: identifier)
         
+        isBordered = false
+        image = NSImage(systemSymbolName: "graduationcap",
+                        accessibilityDescription: "Show sample documents")!
+        self.menu = makeSubmenu()
+    }
+    
+    private func makeSubmenu() -> NSMenu {
         let title = NSLocalizedString("Samples", comment: "Toolbar item's label")
         let menu = NSMenu(title: title)
+        
         let locale = Locale.current
         
         for (tag, languageCode) in languageSource.possibleLanguages.enumerated() {
@@ -191,33 +199,23 @@ public class LanguageButton: NSMenuToolbarItem {
                 title: language,
                 action: #selector(selectLanguage(sender:)),
                 keyEquivalent: "")
+            menuItem.target = self
             
             menuItem.tag = tag
             menuItem.isEnabled = true
+            menuItem.state = languageSource.samplesLanguage == languageCode ? .on : .off
             
             menu.addItem(menuItem)
         }
         
-        self.menu = menu
-        isBordered = false
-        image = NSImage(systemSymbolName: "graduationcap",
-                        accessibilityDescription: "Show sample documents")!
-        
-//        if let currentLanguage = languageSource.samplesLanguage,
-//           let languageTitle = locale.localizedString(forLanguageCode: currentLanguage) {
-//            self.title = languageTitle
-//        } else {
-//            self.title = NSLocalizedString("Samples", comment: "Toolbar item")
-//        }
+        return menu
     }
     
     @objc private func selectLanguage(sender: NSMenuItem) {
         let languageCode = languageSource.possibleLanguages[sender.tag]
         
-        languageSource.presentProjects(with: languageCode)
-    }
-    
-    deinit {
+        languageSource.samplesLanguage = languageCode
         
+        self.menu = makeSubmenu() // Update selected language
     }
 }

--- a/VoiceOver Designer/Features/Sources/Recent/DocumentsTabViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/DocumentsTabViewController.swift
@@ -18,7 +18,7 @@ public class DocumentsTabViewController: NSTabViewController {
         userDocumentsTab.image = NSImage(systemSymbolName: "tray.full", accessibilityDescription: "My documents")
         
         let samplesController = documentsBrowserController(
-            presenter: SamplesDocumentsPresenter(),
+            presenter: SamplesDocumentsPresenter.shared,
             router: router)
         samplesController.title = NSLocalizedString("Samples", comment: "Tab's title")
         let samplesTab = NSTabViewItem(viewController: samplesController)
@@ -102,7 +102,7 @@ extension DocumentsTabViewController {
         case .language:
             guard let languageSource = presenter as? LanguageSource else { return nil }
             
-            let language = LanguageButton(languageSource: languageSource)
+            let language = LanguageButton(languageSource: languageSource, identifier: .language)
             
             return language
         default:
@@ -174,37 +174,50 @@ public class LanguageButton: NSMenuToolbarItem {
     
     private let languageSource: LanguageSource
     
-    init(languageSource: LanguageSource) {
+    public init(languageSource: LanguageSource, 
+                identifier: NSToolbarItem.Identifier) {
         self.languageSource = languageSource
         
-        super.init(itemIdentifier: .language)
+        super.init(itemIdentifier: identifier)
         
-        let title = NSLocalizedString("Language", comment: "Toolbar item's label")
+        let title = NSLocalizedString("Samples", comment: "Toolbar item's label")
         let menu = NSMenu(title: title)
         let locale = Locale.current
         
         for (tag, languageCode) in languageSource.possibleLanguages.enumerated() {
             let language = locale.localizedString(forLanguageCode: languageCode) ?? languageCode
             
-            let menuItem = NSMenuItem(title: language, action: #selector(selectLanguage(sender:)), keyEquivalent: "")
+            let menuItem = NSMenuItem(
+                title: language,
+                action: #selector(selectLanguage(sender:)),
+                keyEquivalent: "")
+            
             menuItem.tag = tag
+            menuItem.isEnabled = true
             
             menu.addItem(menuItem)
         }
         
         self.menu = menu
         isBordered = false
-        if let currentLanguage = languageSource.samplesLanguage,
-           let languageTitle = locale.localizedString(forLanguageCode: currentLanguage) {
-            self.title = languageTitle
-        } else {
-            self.title = NSLocalizedString("Language", comment: "Toolbar item")
-        }
+        image = NSImage(systemSymbolName: "graduationcap",
+                        accessibilityDescription: "Show sample documents")!
+        
+//        if let currentLanguage = languageSource.samplesLanguage,
+//           let languageTitle = locale.localizedString(forLanguageCode: currentLanguage) {
+//            self.title = languageTitle
+//        } else {
+//            self.title = NSLocalizedString("Samples", comment: "Toolbar item")
+//        }
     }
     
     @objc private func selectLanguage(sender: NSMenuItem) {
         let languageCode = languageSource.possibleLanguages[sender.tag]
         
         languageSource.presentProjects(with: languageCode)
+    }
+    
+    deinit {
+        
     }
 }

--- a/VoiceOver Designer/Features/Sources/Recent/DocumentsTabViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/DocumentsTabViewController.swift
@@ -102,28 +102,7 @@ extension DocumentsTabViewController {
         case .language:
             guard let languageSource = presenter as? LanguageSource else { return nil }
             
-            let title = NSLocalizedString("Language", comment: "Toolbar item's label")
-            let menu = NSMenu(title: title)
-            let locale = Locale.current
-            
-            for (tag, languageCode) in languageSource.possibleLanguages.enumerated() {
-                let language = locale.localizedString(forLanguageCode: languageCode) ?? languageCode
-                
-                let menuItem = NSMenuItem(title: language, action: #selector(selectLanguage(sender:)), keyEquivalent: "")
-                menuItem.tag = tag
-                
-                menu.addItem(menuItem)
-            }
-            
-            let language = NSMenuToolbarItem(itemIdentifier: .language)
-            language.menu = menu
-            language.isBordered = false
-            if let currentLanguage = languageSource.samplesLanguage,
-               let languageTitle = locale.localizedString(forLanguageCode: currentLanguage) {
-                language.title = languageTitle
-            } else {
-                language.title = NSLocalizedString("Language", comment: "Toolbar item")
-            }
+            let language = LanguageButton(languageSource: languageSource)
             
             return language
         default:
@@ -146,14 +125,6 @@ extension DocumentsTabViewController {
         }
         
         // TODO: Remember selected tab
-    }
-    
-    @objc func selectLanguage(sender: NSMenuItem) {
-        guard let languageSource = presenter as? LanguageSource else { return }
-        
-        let languageCode = languageSource.possibleLanguages[sender.tag]
-                
-        languageSource.presentProjects(with: languageCode)
     }
 }
 
@@ -185,16 +156,55 @@ extension NSToolbar {
         buttonIndex(identifier: identifier) != nil
     }
     
-    fileprivate func appendItem(with identifer: NSToolbarItem.Identifier) {
-        guard !hasButton(with: identifer) else {
+    fileprivate func appendItem(with identifier: NSToolbarItem.Identifier) {
+        guard !hasButton(with: identifier) else {
             return
         }
         
-        insertItem(withItemIdentifier: identifer, at: items.count)
+        insertItem(withItemIdentifier: identifier, at: items.count)
     }
     
     func resetLanguageButton() {
         removeItem(identifier: .language)
         appendItem(with: .language)
+    }
+}
+
+public class LanguageButton: NSMenuToolbarItem {
+    
+    private let languageSource: LanguageSource
+    
+    init(languageSource: LanguageSource) {
+        self.languageSource = languageSource
+        
+        super.init(itemIdentifier: .language)
+        
+        let title = NSLocalizedString("Language", comment: "Toolbar item's label")
+        let menu = NSMenu(title: title)
+        let locale = Locale.current
+        
+        for (tag, languageCode) in languageSource.possibleLanguages.enumerated() {
+            let language = locale.localizedString(forLanguageCode: languageCode) ?? languageCode
+            
+            let menuItem = NSMenuItem(title: language, action: #selector(selectLanguage(sender:)), keyEquivalent: "")
+            menuItem.tag = tag
+            
+            menu.addItem(menuItem)
+        }
+        
+        self.menu = menu
+        isBordered = false
+        if let currentLanguage = languageSource.samplesLanguage,
+           let languageTitle = locale.localizedString(forLanguageCode: currentLanguage) {
+            self.title = languageTitle
+        } else {
+            self.title = NSLocalizedString("Language", comment: "Toolbar item")
+        }
+    }
+    
+    @objc private func selectLanguage(sender: NSMenuItem) {
+        let languageCode = languageSource.possibleLanguages[sender.tag]
+        
+        languageSource.presentProjects(with: languageCode)
     }
 }

--- a/VoiceOver Designer/Features/Sources/Recent/RecentViewController/Domain/DocumentBrowserPresenterProtocol.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/RecentViewController/Domain/DocumentBrowserPresenterProtocol.swift
@@ -15,8 +15,8 @@ public protocol DocumentBrowserPresenterProtocol {
     func load()
 }
 
-public protocol LanguageSource {
-    var samplesLanguage: String? { get }
+public protocol LanguageSource: AnyObject {
+    var samplesLanguage: String? { get set }
     var possibleLanguages: [String] { get }
     
     func presentProjects(with language: String)
@@ -39,15 +39,6 @@ extension DocumentBrowserPresenterProtocol {
             
             return await VODesignDocument(file: url)
         }
-    }
-}
-
-public class DocumentPresenterFactory {
-    public init() {}
-    
-    public func presenter() -> DocumentBrowserPresenterProtocol {
-//        UserDocumentsPresenter()
-        SamplesDocumentsPresenter()
     }
 }
 

--- a/VoiceOver Designer/Features/Sources/Recent/RecentViewController/Domain/DocumentBrowserPresenterProtocol.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/RecentViewController/Domain/DocumentBrowserPresenterProtocol.swift
@@ -12,9 +12,7 @@ public protocol DocumentBrowserPresenterProtocol {
     func numberOfItemsInSection(_ section: Int) -> Int
     func item(at indexPath: IndexPath) -> DocumentBrowserCollectionItem
     
-    var shouldShowThisController: Bool { get }
     func load()
-    
 }
 
 public protocol LanguageSource {

--- a/VoiceOver Designer/Features/Sources/Recent/RecentViewController/Domain/Samples/SamplesDocumentsPresenter.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/RecentViewController/Domain/Samples/SamplesDocumentsPresenter.swift
@@ -26,8 +26,6 @@ class SamplesDocumentsPresenter: DocumentBrowserPresenterProtocol {
         sections[section].title
     }
     
-    var shouldShowThisController: Bool = true
-    
     private var sections = [ProjectViewModel]()
     var possibleLanguages = [String]()
     var structure: SamplesStructure?

--- a/VoiceOver Designer/Features/Sources/Recent/RecentViewController/Domain/UserDocuments/UserDocumentsPresenter.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/RecentViewController/Domain/UserDocuments/UserDocumentsPresenter.swift
@@ -11,15 +11,8 @@ class UserDocumentsPresenter: DocumentBrowserPresenterProtocol {
     
     public init() {}
     
-    var shouldShowThisController: Bool {
-        let hasRecentDocuments = !recentItems.isEmpty
-        let hasCloudDocuments = !iCloudDocuments.isEmpty
-        
-        return hasRecentDocuments || hasCloudDocuments
-    }
-    
     private var recentItems: [URL] {
-        documentController.recentDocumentURLs ?? []
+        documentController.recentDocumentURLs
     }
     
     private let metadataProvider = MetadataProvider(containerIdentifier: containerId,

--- a/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.storyboard
+++ b/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="KyR-Ji-qI4">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="KyR-Ji-qI4">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -13,7 +13,7 @@
                     <scrollView key="view" wantsLayer="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" id="t9l-ez-YF5" customClass="DocumentsBrowserView" customModule="Recent">
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <clipView key="contentView" id="FcB-rn-by8">
+                        <clipView key="contentView" drawsBackground="NO" id="FcB-rn-by8">
                             <rect key="frame" x="1" y="1" width="448" height="298"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
@@ -23,7 +23,7 @@
                                     <collectionViewFlowLayout key="collectionViewLayout" minimumInteritemSpacing="10" minimumLineSpacing="10" id="Rfx-nn-5v4">
                                         <size key="itemSize" width="50" height="50"/>
                                     </collectionViewFlowLayout>
-                                    <color key="primaryBackgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="primaryBackgroundColor" red="1" green="1" blue="1" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 </collectionView>
                             </subviews>
                         </clipView>

--- a/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.swift
@@ -7,7 +7,6 @@ public protocol RecentRouter: AnyObject {
     func show(document: VODesignDocument) -> Void
 }
 
-
 public class DocumentsBrowserViewController: NSViewController {
 
     public weak var router: RecentRouter?

--- a/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.swift
@@ -83,9 +83,11 @@ extension DocumentsBrowserViewController : NSCollectionViewDataSource {
         viewForSupplementaryElementOfKind kind: NSCollectionView.SupplementaryElementKind,
         at indexPath: IndexPath
     ) -> NSView {
-        let view = collectionView.makeSupplementaryView(ofKind: kind,
-                                                        withIdentifier: HeaderCell.id,
-                                                        for: indexPath) as! HeaderCell
+        let view = collectionView.makeSupplementaryView(
+            ofKind: kind,
+            withIdentifier: HeaderCell.id,
+            for: indexPath) as! HeaderCell
+        
         view.label.stringValue = presenter.title(for: indexPath.section) ?? ""
         return view
     }

--- a/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.swift
+++ b/VoiceOver Designer/Features/Sources/Recent/RecentViewController/UI/DocumentsBrowserViewController.swift
@@ -32,8 +32,6 @@ public class DocumentsBrowserViewController: NSViewController {
             withIdentifier: HeaderCell.id
         )
         presenter.load()
-       
-        
     }
     
     /// Sometimel layout is called right after loading from storyboard, presenter is not set and a crash happened.

--- a/VoiceOver Designer/SingleDocument/PresentationToolbar.swift
+++ b/VoiceOver Designer/SingleDocument/PresentationToolbar.swift
@@ -22,15 +22,26 @@ class PresentationToolbar: NSToolbar {
         NSToolbarItem.editorSideBarItem()
     }()
     
-    lazy var documentsItem: NSToolbarItem = {
-        let item = NSToolbarItem.makeDocumentsItem()
+    lazy var samplesItem: NSToolbarItem = {
+        let item = NSToolbarItem.makeSamplesItem()
+        item.target = self
+        item.action = #selector(showSamplesDidPressed(sender:))
+        return item
+    }()
+    
+    lazy var recentItem: NSToolbarItem = {
+        let item = NSToolbarItem.makeRecentItem()
         item.target = self
         item.action = #selector(showRecentDidPressed(sender:))
         return item
     }()
     
     @objc private func showRecentDidPressed(sender: NSToolbarItem) {
-        actionDelegate?.showRecent()
+        actionDelegate?.showRecent(sender)
+    }
+    
+    @objc private func showSamplesDidPressed(sender: NSToolbarItem) {
+        actionDelegate?.showSamples(sender)
     }
 }
 
@@ -41,7 +52,8 @@ extension PresentationToolbar: NSToolbarDelegate {
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
         switch itemIdentifier {
-        case .documentsButtonLabel: return documentsItem
+        case .recentButtonLabel: return recentItem
+        case .samplesButtonLabel: return samplesItem
         case .editor: return editorSideBarItem
         default: return nil
         }
@@ -49,7 +61,8 @@ extension PresentationToolbar: NSToolbarDelegate {
     
     public func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         return [
-            .documentsButtonLabel,
+            .recentButtonLabel,
+            .samplesButtonLabel,
             .flexibleSpace,
             .editor
         ]

--- a/VoiceOver Designer/SingleDocument/ProjectStateController+Toolbar.swift
+++ b/VoiceOver Designer/SingleDocument/ProjectStateController+Toolbar.swift
@@ -2,7 +2,8 @@ import AppKit
 import Document
 
 protocol ProjectRouterDelegate: AnyObject {
-    func showRecent()
+    func showRecent(_ sender: NSToolbarItem)
+    func showSamples(_ sender: NSToolbarItem)
 }
 
 extension ProjectStateController: NSToolbarDelegate {
@@ -12,7 +13,8 @@ extension ProjectStateController: NSToolbarDelegate {
         willBeInsertedIntoToolbar flag: Bool
     ) -> NSToolbarItem? {
         switch itemIdentifier {
-        case .documentsButtonLabel: return documentsItem()
+        case .recentButtonLabel: return recentItem()
+        case .samplesButtonLabel: return samplesItem()
         case .trailingSidebar: return trailingSideBarItem()
         case .shareDocument: return shareDocumentItem()
         case .itemListTrackingSeparator:
@@ -31,7 +33,8 @@ extension ProjectStateController: NSToolbarDelegate {
             .toggleSidebar,
             .sidebarTrackingSeparator,
             
-            .documentsButtonLabel,
+            .recentButtonLabel,
+            .samplesButtonLabel,
             .shareDocument,
             // Title
             .flexibleSpace,
@@ -51,7 +54,8 @@ extension ProjectStateController: NSToolbarDelegate {
     public func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         var result: [NSToolbarItem.Identifier] = [.toggleSidebar,
          .sidebarTrackingSeparator,
-         .documentsButtonLabel,
+         .recentButtonLabel,
+         .samplesButtonLabel,
          .shareDocument,
          .presentation,
          ]
@@ -68,7 +72,8 @@ extension ProjectStateController: NSToolbarDelegate {
 
     var presentationAllowedItems: [NSToolbarItem.Identifier] {
         [
-            .documentsButtonLabel,
+            .recentButtonLabel,
+            .samplesButtonLabel,
             .editor,
             .shareDocument
         ]
@@ -76,10 +81,17 @@ extension ProjectStateController: NSToolbarDelegate {
 }
 
 extension ProjectStateController {
-    private func documentsItem() -> NSToolbarItem {
-        let item = NSToolbarItem.makeDocumentsItem()
+    private func recentItem() -> NSToolbarItem {
+        let item = NSToolbarItem.makeRecentItem()
         item.target = self
         item.action = #selector(showRecentDidPressed(sender:))
+        return item
+    }
+    
+    private func samplesItem() -> NSToolbarItem {
+        let item = NSToolbarItem.makeSamplesItem()
+        item.target = self
+        item.action = #selector(showSamplesDidPressed(sender:))
         return item
     }
     
@@ -107,7 +119,11 @@ extension ProjectStateController {
     }
 
     @objc private func showRecentDidPressed(sender: NSToolbarItem) {
-        router?.showRecent()
+        router?.showRecent(sender)
+    }
+    
+    @objc private func showSamplesDidPressed(sender: NSToolbarItem) {
+        router?.showSamples(sender)
     }
     
     @objc private func leadingSideBarTapped(sender: NSToolbarItem) {

--- a/VoiceOver Designer/SingleDocument/ProjectStateController+Toolbar.swift
+++ b/VoiceOver Designer/SingleDocument/ProjectStateController+Toolbar.swift
@@ -98,7 +98,7 @@ extension ProjectStateController {
     private func shareDocumentItem() -> NSToolbarItem {
         let item = NSSharingServicePickerToolbarItem(itemIdentifier: .shareDocument)
         item.delegate = document
-        item.isNavigational = true
+//        item.isNavigational = true
         return item
     }
     

--- a/VoiceOver Designer/SingleDocument/RecentWindowController.swift
+++ b/VoiceOver Designer/SingleDocument/RecentWindowController.swift
@@ -9,15 +9,9 @@ import AppKit
 import Document
 import Recent
 
-public protocol RecentDelegate: AnyObject {
-    func createNewDocumentWindow(
-        document: VODesignDocument
-    )
-}
-
 public class RecentWindowController: NSWindowController {
     
-    weak var delegate: RecentDelegate?
+    weak var router: RecentRouter?
     var presenter: DocumentBrowserPresenterProtocol!
     
     public override func windowDidLoad() {
@@ -29,12 +23,5 @@ public class RecentWindowController: NSWindowController {
         window?.titlebarAppearsTransparent = false
         
         shouldCascadeWindows = true
-    }
-}
-
-extension RecentWindowController: RecentRouter {
-    
-    public func show(document: VODesignDocument) {
-        delegate?.createNewDocumentWindow(document: document)
     }
 }

--- a/VoiceOver Designer/SingleDocument/ToolbarItems.swift
+++ b/VoiceOver Designer/SingleDocument/ToolbarItems.swift
@@ -6,7 +6,7 @@
 //
 
 import AppKit
-
+import Recent
 extension NSToolbarItem {
     static func makeRecentItem() -> NSToolbarItem {
         let item = NSToolbarItem(itemIdentifier: .recentButtonLabel)
@@ -21,14 +21,11 @@ extension NSToolbarItem {
     }
     
     static func makeSamplesItem() -> NSToolbarItem {
-        let item = NSToolbarItem(itemIdentifier: .samplesButtonLabel)
-        item.label = NSLocalizedString("Samples", comment: "")
-        
-        item.isBordered = true
-        item.image = NSImage(systemSymbolName: "trophy",
-                             accessibilityDescription: "Show sample documents")!
-        item.toolTip = NSLocalizedString("Go to Samples", comment: "")
+        let item = LanguageButton(
+            languageSource: SamplesDocumentsPresenter.shared,
+            identifier: .samplesButtonLabel)
         item.isNavigational = true
+        item.label = NSLocalizedString("Samples", comment: "")
         return item
     }
     

--- a/VoiceOver Designer/SingleDocument/ToolbarItems.swift
+++ b/VoiceOver Designer/SingleDocument/ToolbarItems.swift
@@ -8,14 +8,26 @@
 import AppKit
 
 extension NSToolbarItem {
-    static func makeDocumentsItem() -> NSToolbarItem {
-        let item = NSToolbarItem(itemIdentifier: .documentsButtonLabel)
+    static func makeRecentItem() -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: .recentButtonLabel)
         item.label = NSLocalizedString("Recent", comment: "")
         
         item.isBordered = true
-        item.image = NSImage(systemSymbolName: "rectangle.grid.3x2",
+        item.image = NSImage(systemSymbolName: "clock",
                              accessibilityDescription: "Show recent documents")!
-        item.toolTip = NSLocalizedString("Go to my documents", comment: "")
+        item.toolTip = NSLocalizedString("Go to My documents", comment: "")
+        item.isNavigational = true
+        return item
+    }
+    
+    static func makeSamplesItem() -> NSToolbarItem {
+        let item = NSToolbarItem(itemIdentifier: .samplesButtonLabel)
+        item.label = NSLocalizedString("Samples", comment: "")
+        
+        item.isBordered = true
+        item.image = NSImage(systemSymbolName: "trophy",
+                             accessibilityDescription: "Show sample documents")!
+        item.toolTip = NSLocalizedString("Go to Samples", comment: "")
         item.isNavigational = true
         return item
     }
@@ -54,7 +66,9 @@ extension NSToolbarItem {
 }
 
 extension NSToolbarItem.Identifier {
-    static let documentsButtonLabel = NSToolbarItem.Identifier(rawValue: "DocumentsButtonLabel")
+    static let recentButtonLabel = NSToolbarItem.Identifier(rawValue: "RecentButtonLabel")
+    static let samplesButtonLabel = NSToolbarItem.Identifier(rawValue: "SamplesButtonLabel")
+    
     static let trailingSidebar = NSToolbarItem.Identifier(rawValue: "TrailingSidebar")
     static let presentation = NSToolbarItem.Identifier(rawValue: "Presentation")
     static let editor = NSToolbarItem.Identifier(rawValue: "Editor")


### PR DESCRIPTION
- [x] Open an empty document on launch
- [x] Create separate buttons for recent and samples
- [x] Open samples in a popup
- [x] Add a hint about samples. Add a sample button as a result.
- [x] Restore language switcher, it was on the toolbar in the window, but there is no window now
- [x] Bug: can open popover several times by pressing on the toolbar item
- [ ] Update screenshots on the site

<img width="1458" alt="Screenshot 2024-01-30 at 22 26 06" src="https://github.com/VODGroup/VoiceOverDesigner/assets/3120680/cfbac563-371c-4dea-aba7-a0eca53e6137">
<img width="1465" alt="Screenshot 2024-01-30 at 22 26 10" src="https://github.com/VODGroup/VoiceOverDesigner/assets/3120680/5105ed16-cca9-46d9-b4ed-396a6ac07647">
