### PR TITLE
Recognize images during drag’n’drop when pasteboard contains URL

### DIFF
--- a/VoiceOver Designer/Features/Sources/CommonUIAppKit/DragNDropImageView.swift
+++ b/VoiceOver Designer/Features/Sources/CommonUIAppKit/DragNDropImageView.swift
@@ -146,6 +146,17 @@ open class DragNDropImageView: NSView {
             foundDocument = true
         }
         
+        for url in pasteboard.imageURLs {
+            if let image = NSImage(contentsOf: url) {
+                delegate?.didDrag(image: image,
+                                  locationInWindow: sender.draggingLocation,
+                                  name: image.name()
+                )
+                
+                foundDocument = true
+            }
+        }
+        
         for url in pasteboard.VODesignURLs {
             delegate?.didDrag(path: url)
             foundDocument = true
@@ -268,6 +279,13 @@ extension NSPasteboard {
                 $0 as? URL
             }.filter {
                 $0.pathExtension.lowercased() == "vodesign"
+            } ?? []
+    }
+    
+    var imageURLs: [URL] {
+        readObjects(forClasses: [NSURL.self], options: nil)?
+            .compactMap {
+                $0 as? URL
             } ?? []
     }
     


### PR DESCRIPTION
Sometimes images can't be drag'n'dropped because the pasteboard contains an image's URL, not the image itself. 